### PR TITLE
test(persistence): fix EmptyDb tests after baseline catalog seed

### DIFF
--- a/tests/FlowHub.Persistence.Tests/Fixtures/PostgresFixture.cs
+++ b/tests/FlowHub.Persistence.Tests/Fixtures/PostgresFixture.cs
@@ -23,7 +23,7 @@ public sealed class PostgresFixture : IAsyncLifetime
 
     public async Task DisposeAsync() => await _container.DisposeAsync();
 
-    public async Task<FlowHubDbContext> CreateFreshDbAsync()
+    public async Task<FlowHubDbContext> CreateFreshDbAsync(bool seedCatalog = true)
     {
         var dbName = $"testdb_{Guid.NewGuid():N}";
 
@@ -39,6 +39,12 @@ public sealed class PostgresFixture : IAsyncLifetime
             .Options;
         var db = new FlowHubDbContext(options);
         await db.Database.MigrateAsync();
+
+        if (!seedCatalog)
+        {
+            await db.Database.ExecuteSqlRawAsync("TRUNCATE TABLE \"Skills\", \"Integrations\" RESTART IDENTITY CASCADE");
+        }
+
         return db;
     }
 }

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfIntegrationHealthServiceTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfIntegrationHealthServiceTests.cs
@@ -10,7 +10,7 @@ public sealed class EfIntegrationHealthServiceTests(PostgresFixture fixture)
     [Fact]
     public async Task GetHealthAsync_ReturnsAllIntegrations()
     {
-        var db = await fixture.CreateFreshDbAsync();
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
         var repo = new EfIntegrationRepository(db);
         await repo.UpsertAsync(new IntegrationHealth("Wallabag", HealthStatus.Healthy, DateTimeOffset.UtcNow.AddMinutes(-1), TimeSpan.FromMilliseconds(180)));
         var sut = new EfIntegrationHealthService(repo);
@@ -25,7 +25,7 @@ public sealed class EfIntegrationHealthServiceTests(PostgresFixture fixture)
     [Fact]
     public async Task GetHealthAsync_MapsDurationMs_ToTimeSpan()
     {
-        var db = await fixture.CreateFreshDbAsync();
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
         var repo = new EfIntegrationRepository(db);
         await repo.UpsertAsync(new IntegrationHealth("Vikunja", HealthStatus.Healthy, null, TimeSpan.FromMilliseconds(250)));
         var sut = new EfIntegrationHealthService(repo);
@@ -38,7 +38,7 @@ public sealed class EfIntegrationHealthServiceTests(PostgresFixture fixture)
     [Fact]
     public async Task GetHealthAsync_EmptyDb_ReturnsEmptyList()
     {
-        var db = await fixture.CreateFreshDbAsync();
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
         var sut = new EfIntegrationHealthService(new EfIntegrationRepository(db));
 
         var result = await sut.GetHealthAsync();

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRegistryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRegistryTests.cs
@@ -10,7 +10,7 @@ public sealed class EfSkillRegistryTests(PostgresFixture fixture)
     [Fact]
     public async Task GetHealthAsync_ReturnsAllSkills()
     {
-        var db = await fixture.CreateFreshDbAsync();
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
         var skillRepo = new EfSkillRepository(db);
         await skillRepo.UpsertAsync(new SkillHealth("Wallabag", HealthStatus.Healthy, 5));
         await skillRepo.UpsertAsync(new SkillHealth("Vikunja", HealthStatus.Degraded, 2));
@@ -26,7 +26,7 @@ public sealed class EfSkillRegistryTests(PostgresFixture fixture)
     [Fact]
     public async Task GetHealthAsync_EmptyDb_ReturnsEmptyList()
     {
-        var db = await fixture.CreateFreshDbAsync();
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
         var sut = new EfSkillRegistry(new EfSkillRepository(db));
 
         var result = await sut.GetHealthAsync();


### PR DESCRIPTION
## Summary
Migration `0005_SeedSkillsAndIntegrations` (commit 738079d) seeds 6 baseline skills + 6 integrations on every `Migrate()`, breaking 5 repository tests that assert "empty DB" or exact row counts.

Adds a `seedCatalog` flag to `PostgresFixture.CreateFreshDbAsync` that `TRUNCATE`s `Skills` + `Integrations` after migration; the 2 affected test classes pass `seedCatalog: false`.

After this change: `FlowHub.Persistence.Tests` = **29 passed / 0 failed** (was 24/5).

Closes the persistence portion of the CI red on main.

## Test plan
- [x] `dotnet test tests/FlowHub.Persistence.Tests` → 29 passed / 0 failed locally
- [ ] CI build-and-test reflects the same persistence numbers (E2E remains red for the unrelated no-server-in-CI reason already tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)