### PR TITLE
docs(readme): link related repos (ai-instructions, agent-pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,10 @@ CAS-AISE project work — see repository owner.
 ## Agent conventions
 
 This repository was developed with heavy AI-assisted engineering. Agent conventions, skills, and the mandatory UI workflow are documented in [`CLAUDE.md`](CLAUDE.md); AI usage per block is in [`docs/ai-usage.md`](docs/ai-usage.md); personal lessons learned in [`vault/Projektarbeit/Learnings.md`](vault/Projektarbeit/Learnings.md).
+
+## Related repositories
+
+Part of the same AI-assisted engineering toolchain:
+
+- [`freaxnx01/ai-instructions`](https://github.com/freaxnx01/ai-instructions) — reusable AI-agent instruction templates (base conventions + per-stack overlays) that this repo's [`CLAUDE.md`](CLAUDE.md), Copilot instructions, and `.ai/` skills are synced from (via the `sync-ai-instructions` skill).
+- [`freaxnx01/agent-pipeline`](https://github.com/freaxnx01/agent-pipeline) — reusable GitHub Actions workflow for autonomous issue → implementation that this repo delegates to via [`.github/workflows/claude.yml`](.github/workflows/claude.yml) (see [`docs/CLAUDE-PIPELINE.md`](docs/CLAUDE-PIPELINE.md)).


### PR DESCRIPTION
Adds a **Related repositories** section to the README linking the two sibling repos in the AI-assisted engineering toolchain:

- [`freaxnx01/ai-instructions`](https://github.com/freaxnx01/ai-instructions) — the instruction templates this repo's `CLAUDE.md`/Copilot/`.ai/` are synced from.
- [`freaxnx01/agent-pipeline`](https://github.com/freaxnx01/agent-pipeline) — the autonomous issue→implementation workflow this repo delegates to (`.github/workflows/claude.yml`, `docs/CLAUDE-PIPELINE.md`).

Note: `agent-pipeline` is the current name of what the workflow/docs still call `claude-pipeline` (GitHub redirects the old name, so existing refs keep working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)