### PR TITLE
docs(ci-cd): clarify GitHub-vs-GitLab choice + deployment scope

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,6 +1,8 @@
 # CI/CD
 
-FlowHub uses three GitHub Actions workflows.
+FlowHub uses three core GitHub Actions workflows.
+
+> **Platform choice — GitHub (not GitLab).** The Block 5 Lernziel names GitHub and the GitLab Agent Platform as the (alternative) hosted CI/CD platforms — it's a GitHub *or* GitLab choice, not both. FlowHub's repository is GitHub-hosted (`github.com/freaxnx01/FlowHub-CAS-AISE`), so CI/CD runs on **GitHub Actions** with GitHub-hosted runners, and **GitHub Copilot** provides inline assistance (see [`ai-usage.md`](ai-usage.md)). The GitLab Agent Platform is GitLab's equivalent of the same capability and is therefore not used.
 
 ## Workflows
 
@@ -35,6 +37,19 @@ git push origin v1.0.0
 **Steps:** Builds a self-contained `efbundle` native binary (no .NET SDK needed at runtime). Uploads as a workflow artifact retained for 30 days.
 
 **How to apply in production:** Download the artifact, copy to the target host, set `ConnectionStrings__Default` env var, run `./efbundle`.
+
+## Deployment scope — automated vs. manual
+
+Where the automation boundary sits, by design:
+
+| Stage | Automation |
+|---|---|
+| Build · test · coverage | **Automated** — `ci.yml` on every push and PR |
+| Image publishing | **Automated** — `release.yml` builds and pushes the `flowhub.web` image to GHCR on `v*` tags |
+| DB migrations bundle | **Automated** — `migrations.yml` produces a runnable `efbundle` artifact (no auto-migrate at app start — 12-Factor XII) |
+| Environment rollout | **Manual, deliberate** — the actual deploy is a one-command `docker compose up` runbook ([`runbooks/public-demo.md`](runbooks/public-demo.md)), not an auto-deploy-on-tag job |
+
+**Why image-publishing is the boundary, not auto-deploy:** FlowHub is a single-operator project with no always-on production environment that needs gated, unattended releases. Publishing a versioned, immutable image to GHCR is the automation that adds value; the rollout itself stays a deliberate, documented one-liner. A CD job that deploys to the VPS on release (SSH or webhook) is a sensible future step rather than a current requirement.
 
 ## Local Development
 

--- a/vault/Blöcke/05 Deployment/05 Deployment - c) Nachbereitung.md
+++ b/vault/Blöcke/05 Deployment/05 Deployment - c) Nachbereitung.md
@@ -30,7 +30,7 @@ In der letzten Nachbearbeitungsphase geht es nun darum, die Lösung zu container
 
 > **FlowHub-Stack-Mapping (.NET + GitHub statt Quarkus + GitLab):**
 > - Containerisierung → Multi-Stage Dockerfile (Build: `mcr.microsoft.com/dotnet/sdk:10.0-alpine`, Runtime: `mcr.microsoft.com/dotnet/aspnet:10.0-alpine`, non-root, siehe `CLAUDE.md` § Docker)
-> - CI/CD → **GitHub Actions** (Repo liegt auf `github.com/freaxnx01/FlowHub-CAS-AISE`); GitLab-Agent-Plattform/-Runner als Lerninhalt zur Kenntnis, Implementierung in GitHub
+> - CI/CD → **GitHub Actions** + GitHub-Runner (Repo liegt auf `github.com/freaxnx01/FlowHub-CAS-AISE`). Das Lernziel nennt GitHub *oder* die GitLab-Agent-Plattform als (alternative) CI/CD-Hosts — FlowHub ist GitHub-gehostet, daher GitHub. Deployment-Automatisierung: CI (build/test) + Release-Workflow (Image-Build & Push nach GHCR auf `v*`-Tags); der eigentliche Rollout ist ein dokumentierter `docker compose`-Runbook-Schritt (Image-Publishing = Automatisierungsgrenze). Details: `docs/ci-cd.md`.
 > - Monitoring/Observability → **OpenTelemetry** (Traces, Metrics, Logs) + Prometheus + Grafana (`/metrics` Endpoint ist im Health-Plan); strukturiertes Logging mit Serilog → stdout (12-Factor XI)
 > - KI-gestützte Apps "mit Quarkus" → mit `Microsoft.Extensions.AI` / Semantic Kernel; KI-Suche via Vector-DB-Provider (z.B. pgvector auf bestehender PostgreSQL aus Block 4)
 > - Kubernetes → Manifests / Helm-Chart (oder lediglich Docker-Compose, falls K8s-Aufwand sprengt — dann begründen)


### PR DESCRIPTION
Addresses the Block 5 Lernziel coverage for CI/CD tooling.

- **Platform choice:** documents that the Lernziel is a GitHub *or* GitLab choice; FlowHub is GitHub-hosted → GitHub Actions + Copilot (GitLab Agent Platform is the GitLab-side equivalent, not used).
- **Deployment scope:** adds an automated-vs-manual table — CI/test, image push to GHCR, and migrations bundle are automated; environment rollout is a deliberate `docker compose` runbook step (image-publishing = automation boundary).
- Aligns the Block 5 Nachbereitung stack-mapping line to the same framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)