### PR TITLE
feat(demo): add Uptime Kuma monitoring to the VPS demo

### DIFF
--- a/demo/docker-compose.vps.yml
+++ b/demo/docker-compose.vps.yml
@@ -58,3 +58,13 @@ services:
       - "traefik.http.routers.flowhub-paperless.tls.certresolver=default"
       - "traefik.http.services.flowhub-paperless.loadbalancer.server.port=8000"
       - "traefik.docker.network=web"
+
+  uptime-kuma:
+    labels: !override
+      - "traefik.enable=true"
+      - "traefik.http.routers.flowhub-status.rule=Host(`status.demo.flowhub.freaxnx01.ch`)"
+      - "traefik.http.routers.flowhub-status.entrypoints=web-secure"
+      - "traefik.http.routers.flowhub-status.tls=true"
+      - "traefik.http.routers.flowhub-status.tls.certresolver=default"
+      - "traefik.http.services.flowhub-status.loadbalancer.server.port=3001"
+      - "traefik.docker.network=web"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -413,6 +413,29 @@ services:
   grafana:
     ports: !reset []
 
+  # Uptime Kuma — lightweight, externally-reachable monitoring for the public demo.
+  # The full Prometheus/Grafana stack stays internal (ports reset above); Kuma adds a
+  # public status page that probes the demo's health endpoints, the skill-target
+  # services, and the LLM provider. Monitors are configured on first boot —
+  # see docs/runbooks/public-demo.md § Uptime monitoring.
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    volumes:
+      - uptime-kuma-data:/app/data
+    labels:
+      # Generic labels (overridden for VPS-DE in demo/docker-compose.vps.yml).
+      - "traefik.enable=true"
+      - "traefik.http.routers.flowhub-status.rule=Host(`status.demo.flowhub.freaxnx01.ch`)"
+      - "traefik.http.routers.flowhub-status.entrypoints=websecure"
+      - "traefik.http.routers.flowhub-status.tls=true"
+      - "traefik.http.routers.flowhub-status.tls.certresolver=letsencrypt"
+      - "traefik.http.services.flowhub-status.loadbalancer.server.port=3001"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:-traefik_public}"
+    networks:
+      - default
+      - traefik_public
+    restart: unless-stopped
+
 networks:
   traefik_public:
     external: true
@@ -428,3 +451,5 @@ volumes:
   # paperless-ngx data (sqlite DB, index) and archived media.
   paperless-data:
   paperless-media:
+  # Uptime Kuma config + monitor history (SQLite). Persists monitors across restarts.
+  uptime-kuma-data:

--- a/docs/runbooks/public-demo.md
+++ b/docs/runbooks/public-demo.md
@@ -14,7 +14,7 @@ A fully open, rate-limited, self-resetting FlowHub instance at <https://demo.flo
 | AI provider | OpenRouter `google/gemma-4-31b-it:free` only. KeywordClassifier auto-fallback on 429/error. `KeywordClassifier` is also the demo's safety net if the daily quota runs out. |
 | Embeddings | **Disabled** — `Embeddings__ApiKey` unset → `AiEmbeddingService` is null → consumer no-ops → `Captures.Embedding` stays NULL. `GET /api/v1/captures/search` returns 503 ProblemDetails with an explanatory body (transparent about what's wired vs not). |
 | Skill integrations | **Vikunja: live** — a self-contained demo Vikunja (sqlite) is provisioned at deploy; `Skills__Vikunja__*` are injected at runtime from the bootstrap env file, so `todo:` captures route to real tasks on a public **writable** link-share (visitors can tick tasks done; wiped every reset). **Wallabag: disabled** — `Skills__Wallabag__*` unset → URL captures stop at `Unhandled`. See "Demo Vikunja" below. |
-| Observability | Prometheus + Grafana **not exposed publicly** — only `flowhub.web` + `postgres` + `rabbitmq` + `flowhub.demo-reset` go through the demo compose overlay. Operator metrics still scrapable via the VPS internal network. |
+| Observability | Prometheus + Grafana **not exposed publicly** — operator metrics stay scrapable via the VPS internal network. A lightweight **Uptime Kuma** instance *is* exposed (`status.demo.flowhub.freaxnx01.ch`) as the public-facing uptime monitor + status page — see [§ Uptime monitoring](#uptime-monitoring). |
 
 ## Topology
 
@@ -153,6 +153,30 @@ Cloudflare DNS for the Vikunja host (added via `homelab-service-routing`): `A` r
 | Dashboard is empty mid-cycle | Reset just ran. Wait < 15 min; fixture seed will appear on the next reset, or trigger an immediate reset via `docker compose exec flowhub.demo-reset /reset.sh`. |
 | Inappropriate user content visible | At most 15 min lifetime. To purge immediately: `docker compose exec flowhub.demo-reset /reset.sh`. |
 | Need to take the demo offline | `docker compose -f docker-compose.yml -f demo/docker-compose.yml down`. Cloudflare DNS can stay; visitors get 522 Origin Unreachable. |
+| Status page / a monitor shows down | Open `status.demo.flowhub.freaxnx01.ch`. App down → check `flowhub.web` logs + `restart` policy. LLM monitor down → OpenRouter outage/quota; demo keeps serving via KeywordClassifier (expected degradation, not an outage). |
+
+## Uptime monitoring
+
+A self-hosted **Uptime Kuma** (`louislam/uptime-kuma`) ships in the demo overlay as the public-facing monitor for the Block 5 *Monitoring & Observability* learning objective. The internal Prometheus/Grafana stack covers deep metrics; Kuma covers **black-box reachability + a public status page** that needs no login to view.
+
+**DNS (one-time):** add `status.demo.flowhub.freaxnx01.ch` → VPS-DE public IP (Cloudflare, proxied) via the `homelab-service-routing` skill, same as the other demo subdomains.
+
+**First-boot setup** (Kuma stores monitors in its own SQLite volume `uptime-kuma-data`, configured via the UI — not declaratively):
+
+1. Open `https://status.demo.flowhub.freaxnx01.ch`, create the admin account.
+2. Add these monitors:
+
+   | Monitor | Type | Target | Notes |
+   |---|---|---|---|
+   | FlowHub app | HTTP(s) – keyword | `https://demo.flowhub.freaxnx01.ch/health/live` | expect `Healthy` |
+   | LLM reachability | HTTP(s) | `https://openrouter.ai/api/v1/models` | provider up? (a down LLM is graceful-degradation, not an app outage) |
+   | Vikunja | HTTP(s) | `https://vikunja.demo.flowhub.freaxnx01.ch` | skill target |
+   | Wallabag | HTTP(s) | `https://wallabag.demo.flowhub.freaxnx01.ch` | skill target |
+   | Paperless | HTTP(s) | `https://paperless.demo.flowhub.freaxnx01.ch` | skill target |
+
+3. Create a **public status page** bundling these monitors — link it from the demo banner / submission as the live monitoring artifact.
+
+> The LLM monitor pings the provider directly because FlowHub has no dedicated LLM health endpoint yet; adding an AI `IHealthCheck` (so the provider also surfaces in `/health`) is a tracked follow-up.
 
 ## Out of scope
 


### PR DESCRIPTION
Closes the biggest gap in the Block 5 *Monitoring & Observability* Lernziel: the live demo had **no monitoring**.

## Changes
- **`demo/docker-compose.yml`** — new `uptime-kuma` service (`louislam/uptime-kuma:1`) + `uptime-kuma-data` volume, generic Traefik labels, `restart: unless-stopped`, on `traefik_public`.
- **`demo/docker-compose.vps.yml`** — VPS-DE label override → route `status.demo.flowhub.freaxnx01.ch` (web-secure / default certresolver / `web` network).
- **`docs/runbooks/public-demo.md`** — posture row updated, operator-runbook row, and a new **Uptime monitoring** section: DNS step, first-boot monitor table (app `/health/live`, **LLM reachability**, Vikunja/Wallabag/Paperless), and public status-page guidance.

## Validation
`docker compose -f docker-compose.yml -f demo/docker-compose.yml -f demo/docker-compose.vps.yml config` parses clean; `uptime-kuma` resolves with the VPS labels.

## Follow-up (noted in runbook)
An AI `IHealthCheck` so the LLM provider also surfaces in `/health` (Kuma currently pings OpenRouter directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)