### PR TITLE
docs: /metrics uptime monitor + LLMeter benchmarking roadmap idea

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -226,6 +226,25 @@ A short, hand-curated Markdown file capturing stable personal facts, e.g.:
 
 ---
 
+## LLM Performance Benchmarking (LLMeter)
+
+**Status:** Idea — not scoped into any Block.
+**Motivation:** Observability today captures *real-world* LLM latency and token usage via OpenTelemetry, but there's no *controlled* characterisation of how the classifier behaves under varying load — how latency scales with Capture size, where concurrency starts to degrade, tokens-per-second per provider/model. That data is what turns "we monitor the LLM" into "we measured and **optimised** it" (the optimisation half of the Block 5 Monitoring Lernziel).
+
+### Proposed shape
+
+1. **Tool** — [LLMeter](https://github.com/awslabs/llmeter), a lightweight LLM-endpoint benchmarking library (latency / throughput / tokens-per-sec across payload sizes and concurrency, with plots). OpenRouter is OpenAI-compatible, so it can target FlowHub's configured provider directly.
+2. **A one-off study, not infra** — a small runnable script + a written result in `docs/insights/` (latency-vs-Capture-size curve, concurrency ceiling, model comparison). Not added to the app or compose.
+3. **Feeds tuning** — results inform classifier timeout, retry/fallback thresholds, and model choice.
+
+### Open questions
+
+- **Cost guard** — the demo's OpenRouter key has a **$1 hard cap**; benchmark runs must be small and rate-limited, or pointed at a separate paid key.
+- Overlap with the existing OTel metrics — LLMeter adds controlled benchmarking on top of live telemetry; decide how much is worth the spend.
+- Whether to keep it manual or wire a periodic CI benchmark (probably manual — cost).
+
+---
+
 ## References
 
 - ADR 0004 — AI Integration in Services (`docs/adr/0004-ai-integration-in-services.md`)

--- a/docs/runbooks/public-demo.md
+++ b/docs/runbooks/public-demo.md
@@ -169,6 +169,7 @@ A self-hosted **Uptime Kuma** (`louislam/uptime-kuma`) ships in the demo overlay
    | Monitor | Type | Target | Notes |
    |---|---|---|---|
    | FlowHub app | HTTP(s) – keyword | `https://demo.flowhub.freaxnx01.ch/health/live` | expect `Healthy` |
+   | FlowHub metrics | HTTP(s) – keyword | `https://demo.flowhub.freaxnx01.ch/metrics` | expect `dotnet` — a runtime metric, present on every scrape; confirms the OTel→Prometheus pipeline is alive end-to-end, not just that the app responds |
    | LLM reachability | HTTP(s) | `https://openrouter.ai/api/v1/models` | provider up? (a down LLM is graceful-degradation, not an app outage) |
    | Vikunja | HTTP(s) | `https://vikunja.demo.flowhub.freaxnx01.ch` | skill target |
    | Wallabag | HTTP(s) | `https://wallabag.demo.flowhub.freaxnx01.ch` | skill target |


### PR DESCRIPTION
- **public-demo runbook:** adds an Uptime Kuma keyword monitor on `/metrics` (keyword `dotnet`, a runtime metric present on every scrape) — confirms the OTel→Prometheus pipeline is alive end-to-end.
- **ROADMAP:** adds *LLM Performance Benchmarking (LLMeter)* — a one-off controlled latency/throughput study for the optimise half of the Block 5 monitoring Lernziel, with the demo $1 cost-cap caveat noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)