### PR TITLE
feat(demo): link Uptime Kuma status page from the demo banner

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       Demo__BannerText: "Public demo — type a capture (top bar) and AI routes it to a live tool: a todo to Vikunja, a URL to Wallabag, or a PDF/image upload (at /captures/new) to paperless-ngx. Open any capture to see its AI classification trace — model, timing, tokens, cost. Data resets every 15 min; semantic search is off."
       Demo__RepoUrl: "https://github.com/freaxnx01/FlowHub-CAS-AISE"
       Demo__WalkthroughUrl: "https://github.com/freaxnx01/FlowHub-CAS-AISE#explainer-videos"
+      Demo__StatusUrl: "https://status.demo.flowhub.freaxnx01.ch/status/flowhub-demo"
       # Demo-only operator notifications to ntfy.sh (set via .env; dormant if unset).
       Demo__Notify__Ntfy__BaseUrl: ${Demo__Notify__Ntfy__BaseUrl:-}
       Demo__Notify__Ntfy__Topic: ${Demo__Notify__Ntfy__Topic:-}

--- a/source/FlowHub.Web/Components/Layout/DemoBanner.razor
+++ b/source/FlowHub.Web/Components/Layout/DemoBanner.razor
@@ -50,6 +50,12 @@
                            Variant="Variant.Text" Size="Size.Small" Color="Color.Inherit"
                            StartIcon="@Icons.Material.Filled.PlayCircle">Walkthrough</MudButton>
             }
+            @if (!string.IsNullOrWhiteSpace(StatusPageUrl))
+            {
+                <MudButton Href="@StatusPageUrl" Target="_blank" rel="noopener noreferrer"
+                           Variant="Variant.Text" Size="Size.Small" Color="Color.Inherit"
+                           StartIcon="@Icons.Material.Filled.MonitorHeart">Status</MudButton>
+            }
             @if (!string.IsNullOrWhiteSpace(RepoUrl))
             {
                 <MudButton Href="@RepoUrl" Target="_blank" rel="noopener noreferrer"

--- a/source/FlowHub.Web/Components/Layout/DemoBanner.razor.cs
+++ b/source/FlowHub.Web/Components/Layout/DemoBanner.razor.cs
@@ -21,6 +21,9 @@ public partial class DemoBanner : ComponentBase
     /// <summary>Link to the explainer-videos section (incl. the demo walkthrough video).</summary>
     [Parameter] public string? WalkthroughUrl { get; set; }
 
+    /// <summary>Public Uptime Kuma status page for the demo (health + uptime monitors).</summary>
+    [Parameter] public string? StatusPageUrl { get; set; }
+
     [Parameter] public string? SkillBoardUrl { get; set; }
 
     /// <summary>Public share of the Vikunja 'Zitate' board, where quote captures land.</summary>

--- a/source/FlowHub.Web/Components/Layout/MainLayout.razor
+++ b/source/FlowHub.Web/Components/Layout/MainLayout.razor
@@ -41,6 +41,7 @@
             <DemoBanner BannerText="@DemoBannerText"
                         RepoUrl="@DemoRepoUrl"
                         WalkthroughUrl="@DemoWalkthroughUrl"
+                        StatusPageUrl="@DemoStatusUrl"
                         SkillBoardUrl="@DemoSkillBoardUrl"
                         ZitateBoardUrl="@DemoZitateBoardUrl"
                         WallabagUrl="@DemoWallabagUrl"

--- a/source/FlowHub.Web/Components/Layout/MainLayout.razor.cs
+++ b/source/FlowHub.Web/Components/Layout/MainLayout.razor.cs
@@ -49,6 +49,8 @@ public partial class MainLayout : LayoutComponentBase
 
     private string? DemoWalkthroughUrl => Configuration["Demo:WalkthroughUrl"];
 
+    private string? DemoStatusUrl => Configuration["Demo:StatusUrl"];
+
     private string? DemoSkillBoardUrl => Configuration["Demo:Vikunja:ShareUrl"];
 
     private string? DemoZitateBoardUrl => Configuration["Demo:Vikunja:ZitateShareUrl"];

--- a/tests/FlowHub.Web.ComponentTests/Layout/DemoBannerTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/Layout/DemoBannerTests.cs
@@ -137,4 +137,26 @@ public class DemoBannerTests : TestContext
 
         cut.Markup.Should().NotContain("Walkthrough");
     }
+
+    [Fact]
+    public void WithStatusPageUrl_RendersClickableStatusLink_OpeningNewTab()
+    {
+        var cut = RenderComponent<DemoBanner>(p => p
+            .Add(c => c.BannerText, "Public demo")
+            .Add(c => c.StatusPageUrl, "https://status.demo.flowhub.freaxnx01.ch/status/flowhub-demo"));
+
+        var link = cut.Find("a[href='https://status.demo.flowhub.freaxnx01.ch/status/flowhub-demo']");
+        link.GetAttribute("target").Should().Be("_blank");
+        link.TextContent.Should().Contain("Status");
+    }
+
+    [Fact]
+    public void WithoutStatusPageUrl_RendersNoStatusLink()
+    {
+        var cut = RenderComponent<DemoBanner>(p => p
+            .Add(c => c.BannerText, "Public demo")
+            .Add(c => c.RepoUrl, "https://github.com/freaxnx01/FlowHub-CAS-AISE"));
+
+        cut.Markup.Should().NotContain("Status");
+    }
 }


### PR DESCRIPTION
Surfaces the live status page in the UI.

- **DemoBanner:** new `StatusPageUrl` parameter → a *Status* quick-link (MonitorHeart icon, opens in new tab), placed with the meta links (Walkthrough/Source).
- **MainLayout:** reads `Demo:StatusUrl` and passes it through.
- **demo/docker-compose.yml:** `Demo__StatusUrl` → `https://status.demo.flowhub.freaxnx01.ch/status/flowhub-demo`.
- **Tests:** 2 bUnit tests (present renders link / absent renders none), TDD red→green; full component suite green (181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)