### PR TITLE
docs(vault/block2): add Lernziel section to Frontend Nachbereitung

### DIFF
--- a/vault/Blöcke/02 Frontend/02 Frontend - c) Nachbereitung.md
+++ b/vault/Blöcke/02 Frontend/02 Frontend - c) Nachbereitung.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - claude-updated
-updated: 2026-05-17
+updated: 2026-06-13
 ---
 
 # Block 2 — Frontend · Nachbereitung
@@ -9,6 +9,15 @@ updated: 2026-05-17
 **Phase budget:** 26 h
 **PVA war:** 2026-03-21
 **Nächste PVA:** 2026-04-25
+
+## Lernziel
+
+- Ich bin in der Lage, verschiedene Technologien und Frameworks für die Entwicklung von Web-Apps einzusetzen.
+- Ich kann die Konzepte von SSR und CSR erklären und anwenden.
+- Ich bin in der Lage, Quarkus für Web-Formulare zu nutzen.
+- Ich bin in der Lage, Unit-Tests zu generieren und Services zu testen.
+
+> **Stack-Mapping (.NET statt Quarkus):** „Quarkus für Web-Formulare" → **Blazor SSR** (.NET-natives Server-Rendering; MudBlazor-Formulare mit Validierung, `MudForm` + `MudTextField`/`MudSelect`). Quarkus ist im Moodle-Auftrag nur Beispiel-Stack — die Lernziele (SSR/CSR, Web-Frameworks, Unit-Tests) sind stack-neutral und mit Blazor erfüllt.
 
 ## Auftrag (Moodle)
 


### PR DESCRIPTION
Block 2 (Frontend) was the only block without a `## Lernziel` section. Adds the four official Frontend Lernziele (sourced from `nachbereitung/AISE_Projektarbeit_Auftraege.md`) + the Blazor-vs-Quarkus stack-mapping note, matching blocks 1/3/4/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)