### PR TITLE
chore(gitignore): ignore local lernziele.md (FFHS course material)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -443,6 +443,8 @@ flowhub.db-wal
 vault/_files/Moodle/
 **/Moodle/Modul/
 *_Moodle.pdf
+# Verbatim per-block Lernziele (FFHS course material) — local reference only
+lernziele.md
 
 # Submission PDF build artefacts (regenerated from SUBMISSION.md on demand)
 SUBMISSION.pdf


### PR DESCRIPTION
Adds `lernziele.md` to `.gitignore` under the FFHS-copyright Moodle section. The file holds the verbatim per-block Lernziele (course material) and stays a local-only reference — never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)