### PR TITLE
docs(readme): fix stale repo-tree note for purged rubric

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ docs/                   ← architecture, specs, runbooks, insights
 vault/                  ← Obsidian vault — CAS coursework and project notes
   Projektarbeit/        ← idea, dev notes, glossary, learnings
   Blöcke/01..05/        ← per-block Vorbereitung / PVA / Nachbereitung
-  Organisation/         ← Bewertungskriterien (Moodle rubric)
+  Organisation/         ← course-org notes (enrolment, dates, costs); rubric is FFHS IP, kept local only
 SUBMISSION.md           ← the Moodle submission document (rendered to PDF)
 docs/project/submission-notes.md  ← operator notes: how the submission PDF is produced
 ```


### PR DESCRIPTION
Tiny consistency fix from the pre-submission check: the README structure tree still listed `Organisation/ ← Bewertungskriterien (Moodle rubric)`, but that file was purged (FFHS IP, kept local). Updated to describe the folder's real contents (enrolment/dates/costs) and note the rubric is local-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)