### PR TITLE
docs: reconcile default-suite test count to 294

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Requires .NET 10 SDK (`global.json` pins the version). The `justfile` exposes ev
 
 ```bash
 just build       # build the full solution (warnings as errors)
-just test        # run the default suite — 253 tests (excludes live AI / BetaSmoke / E2E)
+just test        # run the default suite — 294 tests (excludes live AI / BetaSmoke / E2E)
 just run         # run FlowHub.Web on http://localhost:5070
 just watch       # same, with hot reload
 ```

--- a/docs/spec/testing-strategy.md
+++ b/docs/spec/testing-strategy.md
@@ -44,9 +44,9 @@ graph TD
 > | This section / Block 3 | 3 | `Category!=AI` (default suite) | 99 |
 > | Block 4 Nachbereitung (`docs/insights/block-4.md`) | 4 | `FullyQualifiedName!~E2ETests` (incl. AI + integration) | 223 (6 skipped) |
 > | Block 5 Nachbereitung (`docs/insights/block-5.md`) | 5 | `Category!=AI&!=BetaSmoke&!=E2E` (offline default suite) | 171 (0 skipped) |
-> | **Submission build (this doc)** | 5 | `Category!=AI&!=BetaSmoke&!=E2E` (offline default suite) | **292 (0 skipped)** |
+> | **Submission build (this doc)** | 5 | `Category!=AI&!=BetaSmoke&!=E2E` (offline default suite) | **294 (0 skipped)** |
 >
-> **Canonical figure at submission:** **292 offline tests green, 0 failed, 0
+> **Canonical figure at submission:** **294 offline tests green, 0 failed, 0
 > skipped** (the default CI suite), and the suite additionally passes the AI +
 > live-service integration tests when their categories are enabled (E2E excluded).
 > The lower historical numbers are earlier per-block snapshots, retained in the
@@ -54,7 +54,7 @@ graph TD
 
 ### Verified test run (rendered evidence)
 
-Output of `just test` (`dotnet test FlowHub.slnx --filter "Category!=AI&Category!=BetaSmoke&Category!=E2E"`), run **2026-06-12**:
+Output of `just test` (`dotnet test FlowHub.slnx --filter "Category!=AI&Category!=BetaSmoke&Category!=E2E"`), run **2026-06-16**:
 
 | Test project | Passed | Failed | Skipped |
 |---|---:|---:|---:|
@@ -62,9 +62,9 @@ Output of `just test` (`dotnet test FlowHub.slnx --filter "Category!=AI&Category
 | FlowHub.Skills.ContractTests | 17 | 0 | 0 |
 | FlowHub.Api.IntegrationTests | 21 | 0 | 0 |
 | FlowHub.Skills.Tests | 31 | 0 | 0 |
-| FlowHub.Web.ComponentTests (bUnit) | 179 | 0 | 0 |
+| FlowHub.Web.ComponentTests (bUnit) | 181 | 0 | 0 |
 | FlowHub.Persistence.Tests (Testcontainers, real PostgreSQL) | 38 | 0 | 0 |
-| **Total** | **292** | **0** | **0** |
+| **Total** | **294** | **0** | **0** |
 
 `Passed! - Failed: 0, …` for every assembly; the persistence suite runs against a
 real PostgreSQL container via Testcontainers (not InMemory). AI- and E2E-tagged
@@ -165,7 +165,7 @@ public sealed class AnthropicHaikuLiveTests
 #### Trait filtering strategy
 
 Tests use `[Trait("Category", "AI")]` to partition:
-- **Default suite** (`Category!=AI&Category!=BetaSmoke&Category!=E2E`): 292 tests, runs every build, no external dependencies
+- **Default suite** (`Category!=AI&Category!=BetaSmoke&Category!=E2E`): 294 tests, runs every build, no external dependencies
 - **Live AI suite** (`Category=AI`): 4 tests, runs on-demand, requires real API credentials
 
 ## Test Naming Convention

--- a/nachbereitung/examiner-sim/defense-prep.md
+++ b/nachbereitung/examiner-sim/defense-prep.md
@@ -100,11 +100,12 @@ GraalVM native image — a lean Alpine container isn't AOT.)
 ## D. Validierung
 
 **Q: How many tests, and what does CI actually prove?**
-A: **171** offline tests green (default suite: `Category!=AI&!=BetaSmoke&!=E2E`),
-**223** green including AI + live-service integration (E2E excluded). The different
-numbers across docs are per-block / per-filter snapshots — see the reconciliation
-table in `docs/spec/testing-strategy.md`. CI proves the offline suite; AI/E2E are
-trait-gated and run on demand.
+A: **294** offline tests green (default CI suite: `Category!=AI&!=BetaSmoke&!=E2E`),
+0 failed, 0 skipped; the suite additionally passes the trait-gated AI + live-service
+integration tests when enabled (E2E excluded). The lower numbers in the
+Nachbereitungen (31, 99, 171, 223) are earlier per-block / per-filter snapshots — see
+the reconciliation table in `docs/spec/testing-strategy.md`. CI proves the offline
+suite; AI/E2E are trait-gated and run on demand.
 
 **Q: Why Testcontainers over EF InMemory for persistence tests?**
 A: Real PostgreSQL catches what InMemory can't: pgvector queries, FK cascade
@@ -159,7 +160,7 @@ record the shift with concrete incidents (e.g. dual-provider EF trap, N+1 `.Incl
 
 **Done — earlier doc passes (shipped):** NF-table relabel, as-built §6.1 + rendered
 diagrams, XML-doc on the Core ports, removed the empty Integrations/Telegram folders,
-verified-test-run embedded (253/0/0). These already landed.
+verified-test-run embedded (294/0/0). These already landed.
 
 **Resolved by the June-2026 rubric update — no longer a gap:** the "independent
 first-party container" requirement. The rubric now accepts a **modular monolith run


### PR DESCRIPTION
## Why
A fresh `just test` run (2026-06-16) shows **294 offline tests green, 0 failed, 0 skipped**. The suite grew by 2 bUnit component tests (179→181) since the 2026-06-12 evidence run, so `testing-strategy.md` (292) and a couple of quick-start/prep mentions were stale. `SUBMISSION.md` already cited 294 — this aligns the stragglers.

## What
- **testing-strategy.md** — submission table `179→181`, total + canonical figure `292→294`, evidence run re-dated to 2026-06-16.
- **README.md** — quick-start `just test` comment `253→294`.
- **defense-prep.md** — current-figure `171→294`, embedded run `253→294`.

Dated per-block snapshots (block-4 `223`, block-5 `171`, CHANGELOG `171`) are **left as-is** — they're historical progress records, preserved by the reconciliation table.

Verified: `just test` → 294/0/0 across 6 projects (Core 6, ContractTests 17, Skills 31, Api.Integration 21, ComponentTests 181, Persistence 38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)