### PR TITLE
docs(blocks): paraphrase verbatim Moodle Lernziele + neutralize Quarkus

### DIFF
--- a/vault/Blöcke/01 Einführung/01 Einführung - c) Nachbereitung.md
+++ b/vault/Blöcke/01 Einführung/01 Einführung - c) Nachbereitung.md
@@ -12,11 +12,11 @@ updated: 2026-05-17
 
 ## Lernziel
 
-- Ich kann ein KI-gestütztes Software-Engineering-Projekt initial aufsetzen und die wichtigsten Architekturentscheidungen begründen.
-- Ich kann Software-Architekturoptionen (Monolith, Modular Monolith, Microservices) für ein Projektszenario gegeneinander abwägen.
-- Ich kann das Tooling für KI-assistierte Entwicklung (Claude Code, IDE-Integration, Skills) für ein neues Repository einrichten.
+- Ein KI-gestütztes Software-Engineering-Projekt von Grund auf aufsetzen und die tragenden Architekturentscheidungen begründen.
+- Architekturstile (Monolith, modularer Monolith, Microservices) für ein Szenario gegeneinander abwägen und die Wahl begründen.
+- Die KI-Werkzeugkette (Claude Code, IDE-Integration, eigene Skills) für ein neues Repository einrichten.
 
-## Auftrag (Moodle)
+## Auftrag (Zusammenfassung)
 
 - Sichtung der Materialien und Ergebnisse der Präsenzveranstaltung 1
 - Projektbeschreibung verfassen (Idee, Solution Vision, fokussierte Sub-Systeme, Beispiel-Eingabedaten)
@@ -35,7 +35,7 @@ Snapshot am Ende der Block-1-Phase (~2026-03-21) gegen die offizielle Moodle-Rub
 
 > **Sektion nachträglich ergänzt (2026-05-17)** — damit das Pattern aus Block 3 / 4 / 5 auch in Block 1 / 2 vorhanden ist.
 
-> **Rubrik-Update Juni 2026:** Das Programmierkriterium ist jetzt framework-neutral (nicht mehr Quarkus/Jakarta-EE-spezifisch) und für FlowHub (.NET) **direkt erfüllt** — kein ausgeklammertes Item mehr, alle 100 Punkte erreichbar (siehe `vault/Organisation/Bewertungskriterien.md` + `docs/spec/modern-app-concepts.md`).
+> **Rubrik-Update (Juni 2026):** Programmierkriterium ist framework-neutral → für .NET direkt erfüllt, alle 100 Punkte erreichbar (`docs/spec/modern-app-concepts.md`).
 
 ### Spezifikation
 

--- a/vault/Blöcke/02 Frontend/02 Frontend - c) Nachbereitung.md
+++ b/vault/Blöcke/02 Frontend/02 Frontend - c) Nachbereitung.md
@@ -12,14 +12,14 @@ updated: 2026-06-13
 
 ## Lernziel
 
-- Ich bin in der Lage, verschiedene Technologien und Frameworks für die Entwicklung von Web-Apps einzusetzen.
-- Ich kann die Konzepte von SSR und CSR erklären und anwenden.
-- Ich bin in der Lage, Quarkus für Web-Formulare zu nutzen.
-- Ich bin in der Lage, Unit-Tests zu generieren und Services zu testen.
+- Verschiedene Web-Frameworks und Rendering-Technologien gezielt einsetzen.
+- Server- und Client-seitiges Rendering (SSR/CSR) erklären und anwenden.
+- Ein server-seitiges Framework für Web-Formulare einsetzen.
+- KI-generierte Unit-Tests erstellen und Services damit absichern.
 
-> **Stack-Mapping (.NET statt Quarkus):** „Quarkus für Web-Formulare" → **Blazor SSR** (.NET-natives Server-Rendering; MudBlazor-Formulare mit Validierung, `MudForm` + `MudTextField`/`MudSelect`). Quarkus ist im Moodle-Auftrag nur Beispiel-Stack — die Lernziele (SSR/CSR, Web-Frameworks, Unit-Tests) sind stack-neutral und mit Blazor erfüllt.
+> **Stack-Mapping:** Server-seitiges Rendering für Web-Formulare → **Blazor SSR** (.NET-natives Server-Rendering; MudBlazor-Formulare mit Validierung, `MudForm` + `MudTextField`/`MudSelect`). Der Kurs nennt Quarkus/Qute als Beispiel-Stack — die Lernziele (SSR/CSR, Web-Frameworks, Unit-Tests) sind stack-neutral und mit Blazor erfüllt.
 
-## Auftrag (Moodle)
+## Auftrag (Zusammenfassung)
 
 - Tech-Entscheid Präsentationsschicht (CSR/SSR/Mix) + Begründung
 - Wireframes für FlowHub-Frontend
@@ -36,7 +36,7 @@ Snapshot am Ende der Block-2-Phase (~2026-04-25) gegen die offizielle Moodle-Rub
 
 > **Sektion nachträglich ergänzt (2026-05-17)** — damit das Pattern aus Block 3 / 4 / 5 auch in Block 1 / 2 vorhanden ist.
 
-> **Rubrik-Update Juni 2026:** Das Programmierkriterium ist jetzt framework-neutral (nicht mehr Quarkus/Jakarta-EE-spezifisch) und für FlowHub (.NET) **direkt erfüllt** — kein ausgeklammertes Item mehr, alle 100 Punkte erreichbar (siehe `vault/Organisation/Bewertungskriterien.md` + `docs/spec/modern-app-concepts.md`).
+> **Rubrik-Update (Juni 2026):** Programmierkriterium ist framework-neutral → für .NET direkt erfüllt, alle 100 Punkte erreichbar (`docs/spec/modern-app-concepts.md`).
 
 ### Spezifikation
 

--- a/vault/Blöcke/03 Service/03 Service - c) Nachbereitung.md
+++ b/vault/Blöcke/03 Service/03 Service - c) Nachbereitung.md
@@ -13,11 +13,11 @@ updated: 2026-05-04
 
 ## Lernziel
 
-- Ich kann Microservices- und Service-based Architekturen entwerfen.
-- Ich bin fähig, die verschiedenen Protokolle wie SOAP, REST und gRPC zu nutzen.
-- Ich kann Service-Discovery und Service-Mesh für GenAI entwickeln.
-- Ich kann mit KI flexible Microservice-Architekturen bauen.
-- Ich kann mit Spring-AI und Koog AI Agenten bauen.
+- Service- und Microservice-orientierte Architekturen entwerfen.
+- Gängige Service-Protokolle einordnen und einsetzen (z. B. REST, gRPC, SOAP).
+- Service-Discovery- und Service-Mesh-Konzepte für KI-gestützte Dienste verstehen.
+- Mit KI flexible, resiliente Service-Architekturen bauen.
+- KI-Agenten mit einem geeigneten Agent-Framework bauen.
 
 ## Auftrag (Zusammenfassung)
 
@@ -42,7 +42,7 @@ updated: 2026-05-04
 
 Pflichtcheck am Ende jeder Nachbereitung — die offizielle Moodle-Rubrik aus [[Bewertungskriterien]] für **diesen** Block durchgehen, bevor "fertig" geclaimed wird. Punkteangaben in Klammern zeigen Max-Score (volle Erfüllung).
 
-> **Rubrik-Update Juni 2026:** Das Programmierkriterium ist jetzt framework-neutral (nicht mehr Quarkus/Jakarta-EE-spezifisch) und für FlowHub (.NET) **direkt erfüllt** — kein ausgeklammertes Item mehr, alle 100 Punkte erreichbar (siehe `vault/Organisation/Bewertungskriterien.md` + `docs/spec/modern-app-concepts.md`).
+> **Rubrik-Update (Juni 2026):** Programmierkriterium ist framework-neutral → für .NET direkt erfüllt, alle 100 Punkte erreichbar (`docs/spec/modern-app-concepts.md`).
 
 ### Spezifikation
 

--- a/vault/Blöcke/04 Persitence/04 Persitence - c) Nachbereitung.md
+++ b/vault/Blöcke/04 Persitence/04 Persitence - c) Nachbereitung.md
@@ -13,10 +13,10 @@ updated: 2026-05-06
 
 ## Lernziel
 
-- Ich kann für die jeweilige Problemstellung die geeignete Persistenzform bestimmen.
-- Ich kann mit Spezifikationen wie ORM, JPA und Alternativen den DB-Zugriff abstrahieren.
-- Ich kann dynamische Abfragen effizient programmieren.
-- Ich kann mit Quarkus Panache Datenzugriffe auf verschiedene Datenbankmodelle realisieren.
+- Die passende Persistenzform für eine gegebene Problemstellung bestimmen.
+- Den Datenbankzugriff über eine ORM-Abstraktion kapseln.
+- Dynamische Abfragen effizient und typsicher formulieren.
+- Datenzugriffe über ein ORM auf unterschiedliche Datenbankmodelle umsetzen.
 
 ## Auftrag (Zusammenfassung)
 
@@ -54,7 +54,7 @@ Die **Persistenzschicht** (dritte/letzte Schicht einer klassischen Enterprise-Ap
 
 Pflichtcheck am Ende jeder Nachbereitung — die offizielle Moodle-Rubrik aus [[Bewertungskriterien]] für **diesen** Block durchgehen, bevor "fertig" geclaimed wird. Punkteangaben in Klammern zeigen Max-Score.
 
-> **Rubrik-Update Juni 2026:** Das Programmierkriterium ist jetzt framework-neutral (nicht mehr Quarkus/Jakarta-EE-spezifisch) und für FlowHub (.NET) **direkt erfüllt** — kein ausgeklammertes Item mehr, alle 100 Punkte erreichbar (siehe `vault/Organisation/Bewertungskriterien.md` + `docs/spec/modern-app-concepts.md`).
+> **Rubrik-Update (Juni 2026):** Programmierkriterium ist framework-neutral → für .NET direkt erfüllt, alle 100 Punkte erreichbar (`docs/spec/modern-app-concepts.md`).
 
 ### Spezifikation
 

--- a/vault/Blöcke/05 Deployment/05 Deployment - c) Nachbereitung.md
+++ b/vault/Blöcke/05 Deployment/05 Deployment - c) Nachbereitung.md
@@ -15,10 +15,10 @@ updated: 2026-06-12
 
 ## Lernziel
 
-- Ich bin fähig, meine Applikation zu containerisieren und in Docker und Kubernetes zu betreiben.
-- Ich kann GitHub und Copilot sowie die GitLab-Agent-Plattform einsetzen, um CI/CD-Pipelines aufzusetzen und den Deployment-Prozess zu automatisieren.
-- Ich bin fähig, entsprechendes Monitoring und Observation aufzusetzen, Systeme zu überwachen und zu optimieren.
-- Ich bin in der Lage, mit Quarkus KI-gestützte Applikationen zu bauen.
+- Die Applikation containerisieren und in Docker / Kubernetes betreiben.
+- CI/CD-Pipelines auf einer Git-Host-Plattform aufsetzen und das Deployment automatisieren.
+- Monitoring und Observability aufsetzen, um das System zu überwachen und zu optimieren.
+- KI-gestützte Applikationen bauen.
 
 ## Auftrag (Zusammenfassung)
 
@@ -47,7 +47,7 @@ Abschlussphase — die Lösung betriebsbereit machen und einreichen:
 
 ⚠️ **Hier zählt's:** Alle 18 Items aus [[Bewertungskriterien]] müssen Abgabe-fähig sein. Punkte in Klammern = Max-Score.
 
-> **Rubrik-Update Juni 2026:** Das Programmierkriterium ist jetzt framework-neutral (nicht mehr Quarkus/Jakarta-EE-spezifisch) und für FlowHub (.NET) **direkt erfüllt** — kein ausgeklammertes Item mehr, alle 100 Punkte erreichbar (siehe `vault/Organisation/Bewertungskriterien.md` + `docs/spec/modern-app-concepts.md`).
+> **Rubrik-Update (Juni 2026):** Programmierkriterium ist framework-neutral → für .NET direkt erfüllt, alle 100 Punkte erreichbar (`docs/spec/modern-app-concepts.md`).
 
 ### Spezifikation
 


### PR DESCRIPTION
## Why
An IP/consistency audit found the per-block `## Lernziel` lists were the **official course learning objectives, copied verbatim** (instructor IP) — and they still named **Quarkus / Panache / Spring-AI / Koog / Qute / GitLab**, the exact stack we deliberately replaced with .NET, undercutting the framework-neutral narrative.

## What
- Rewrote all 5 Lernziel lists into **own words, stack-neutral** (each block's Stack-Mapping note already bridges course-stack → .NET).
- Unified Block 1/2 `Auftrag (Moodle)` → `Auftrag (Zusammenfassung)` (content was already summarised) to match Blocks 3–5.
- One-lined the identical "Rubrik-Update Juni 2026" callout repeated across all 5 blocks.

No graded evidence removed — per-block rubric self-checks intact.

## On the broader "shortening pass"
Verified the other audit targets directly: `acceptance-criteria.md` is already compact tables, and `docs/adr/README.md` + `docs/ci-cd.md` are legitimate graded evidence (architectural rigor; Block-5 deployment rationale), not boilerplate. Declined to cut them. The real page reduction already shipped via the 340→267 bundle trim (#72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)