### PR TITLE
feat(pdf): concise self-contained main submission doc (~37pp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -459,6 +459,7 @@ vault/_files/weiterbildung-cas-ai-assisted-software-engineering-de.pdf
 # Submission PDF build artefacts (regenerated from SUBMISSION.md on demand)
 SUBMISSION.pdf
 SUBMISSION-bundle.pdf
+SUBMISSION-main.pdf
 tools/build/
 Eigenständigkeitserklärung.pdf
 

--- a/justfile
+++ b/justfile
@@ -632,6 +632,15 @@ pdf-submission-bundle:
     tools/submission-bundle.sh tools/build/submission-bundle.md
     node {{pdf_renderer}} tools/build/submission-bundle.md SUBMISSION-bundle.pdf --title "FlowHub — CAS AISE Submission Bundle"
 
+# Build SUBMISSION-main.pdf — concise self-contained reading doc (Projektbeschreibung + rubric self-check)
+[group('pdf')]
+pdf-submission-main:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d "{{pdf_tool_dir}}/node_modules" ]; then just pdf-install; fi
+    tools/submission-main.sh tools/build/submission-main.md
+    node {{pdf_renderer}} tools/build/submission-main.md SUBMISSION-main.pdf --title "FlowHub — CAS AISE Projektarbeit (Hauptdokument)"
+
 # Build Eigenständigkeitserklärung.pdf (FFHS Hilfsmittelverzeichnis + signed declaration; compact layout)
 [group('pdf')]
 pdf-eigenstaendigkeitserklaerung:

--- a/tools/submission-main.sh
+++ b/tools/submission-main.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build the concise, self-contained MAIN reading document of the submission:
+# a slim cover + the full Projektbeschreibung (Vision → Architektur → ADRs →
+# KI-Reflexion) + a Lernziele-/Rubrik-Abdeckung self-check. ~30 pages.
+#
+# This is the document an examiner reads end-to-end without browsing GitHub.
+# It is distinct from:
+#   - SUBMISSION.md / SUBMISSION.pdf — the 7-page hub that links every artefact
+#   - SUBMISSION-bundle.pdf — the complete, everything-inlined offline archive
+#
+# Output is consumed by tools/md-to-pdf/render.mjs.
+# Usage: tools/submission-main.sh [<output-md-path>]   (default: tools/build/submission-main.md)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-$ROOT/tools/build/submission-main.md}"
+mkdir -p "$(dirname "$OUT")"
+
+# Each entry: <heading depth>|<title>|<path-relative-to-repo-root>
+FILES=(
+  "1|Projektbeschreibung|docs/projektbeschreibung/FlowHub_Projektbeschreibung_v4.md"
+  "1|Lernziele- & Rubrik-Abdeckung (Self-Check)|docs/lernziele-coverage.md"
+)
+
+# Slim cover (this document is meant to be read; keep it short).
+cat > "$OUT" <<'COVER'
+# FlowHub — CAS AISE Projektarbeit · Hauptdokument
+
+**CAS AI-Assisted Software Engineering (AISE)** · W4B-C-AS001 · ZH-Sa-1 · FS26
+**Student:** Andreas Imboden
+**Repository:** <https://github.com/freaxnx01/FlowHub-CAS-AISE>
+**Abgabedatum:** 2026-07-04
+
+> **Lesehinweis.** Dies ist die kompakte, in sich geschlossene Lesefassung der
+> Projektarbeit: die vollständige **Projektbeschreibung** (Vision, Stakeholder,
+> Funktionsumfang, **Systemarchitektur mit Diagrammen**, Architekturentscheidungen,
+> KI-Reflexion, Risiken) und eine **Lernziele-/Rubrik-Abdeckung** als Self-Check.
+>
+> Für den vollständigen Quellcode und alle Detail-Artefakte (ADR-Volltexte,
+> Block-Nachbereitungen, Test-Strategie, Sequenzdiagramme) siehe das Repository.
+> Die Einreichungs-Seite `SUBMISSION.md` (separates PDF) verlinkt jedes einzelne
+> Artefakt direkt; `SUBMISSION-bundle.pdf` ist das vollständige Offline-Archiv.
+COVER
+
+for entry in "${FILES[@]}"; do
+  depth="${entry%%|*}"
+  rest="${entry#*|}"
+  title="${rest%%|*}"
+  path="${rest#*|}"
+
+  if [[ ! -f "$ROOT/$path" ]]; then
+    echo "submission-main: missing file: $path" >&2
+    exit 1
+  fi
+
+  {
+    printf '\n\n<div style="page-break-before: always;"></div>\n\n'
+    printf '%s %s\n\n' "$(printf '#%.0s' $(seq 1 "$depth"))" "$title"
+    printf '_Source: `%s`_\n\n' "$path"
+    cat "$ROOT/$path"
+  } >> "$OUT"
+done
+
+echo "submission-main: wrote $OUT ($(wc -l < "$OUT") lines)"


### PR DESCRIPTION
## Why
The submission had two extremes: the **7-page hub** (links only — relies on the examiner browsing GitHub) and the **267-page bundle** (everything inlined — too much to read). Neither is a document an examiner reads end-to-end to grade.

## What
Adds `just pdf-submission-main` → **SUBMISSION-main.pdf (~37pp)**: a self-contained reading document =
- slim cover + reading guide,
- the full **Projektbeschreibung** (Vision → Stakeholder → Funktionsumfang → **§6 Systemarchitektur with rendered diagrams** → ADRs → KI-Reflexion → Risiken),
- the **Lernziele-/Rubrik-Abdeckung** self-check.

It uses the offline-mermaid renderer, so it ships with rendered diagrams and a 53-entry bookmark outline. The generated PDF is gitignored like the other submission PDFs.

## Submission model (recommended upload)
- **SUBMISSION-main.pdf** — the readable main document (this).
- **SUBMISSION.pdf** (7pp hub) — the clickable artefact index into GitHub.
- SUBMISSION-bundle.pdf (267pp) stays in the repo as the complete offline archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)