### PR TITLE
docs(submission): numbered upload set (00–04) + package-submission recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -469,3 +469,6 @@ source/FlowHub.Web/App_Data/uploads/
 # Windows / file-manager cruft (NTFS mark-of-the-web ADS, trashed files)
 *:Zone.Identifier
 .trashed-*
+
+# Numbered Moodle upload set (assembled on demand)
+upload/

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -9,7 +9,7 @@
 
 ## Hinweis zum Aufbau dieses Dokuments
 
-Diese Datei (`FlowHub_Uebersicht.pdf`) ist der **Einstieg in die Abgabe**: Sie beginnt mit der Dokumentenübersicht und enthält danach eine kurze Projektzusammenfassung sowie ein klickbares Inhaltsverzeichnis aller Artefakte. Die vollständigen Inhalte liegen im verlinkten GitHub-Repository; sämtliche Links zeigen auf den `main`-Branch und sind aus dem PDF heraus klickbar.
+Diese Datei (`00-FlowHub_Uebersicht.pdf`) ist der **Einstieg in die Abgabe**: Sie beginnt mit der Dokumentenübersicht und enthält danach eine kurze Projektzusammenfassung sowie ein klickbares Inhaltsverzeichnis aller Artefakte. Die vollständigen Inhalte liegen im verlinkten GitHub-Repository; sämtliche Links zeigen auf den `main`-Branch und sind aus dem PDF heraus klickbar.
 
 ---
 
@@ -19,11 +19,11 @@ Diese Datei (`FlowHub_Uebersicht.pdf`) ist der **Einstieg in die Abgabe**: Sie b
 
 | # | Dokument | Seiten | Inhalt |
 |---|---|---:|---|
-| 1 | **FlowHub_Uebersicht** *(diese Datei)* | 8 | Einstieg: Dokumentenübersicht + Projektzusammenfassung + klickbares Inhaltsverzeichnis |
-| 2 | **FlowHub_Arc42_v2** — Architektur (as built) | 24 | 12 arc42-Kapitel, 9 Diagramme (System-Kontext, Bausteine, Lebenszyklus, Sequenzen, ER) |
-| 3 | **FlowHub_Reflexion** | 7 | KI-Werkzeuge, Workflow-Entwicklung Block 1→5, Stärken/Fehlerquellen, Fazit |
-| 4 | **flowhub-praesentation** | 18 | Foliensatz: Teil 1 Produkt, Teil 2 Bauen mit KI |
-| 5 | **Eigenständigkeitserklärung** | 2 | Hilfsmittelverzeichnis + unterschriebene Erklärung |
+| 0 | **`00-FlowHub_Uebersicht.pdf`** *(diese Datei)* | 8 | Einstieg: Dokumentenübersicht + Projektzusammenfassung + klickbares Inhaltsverzeichnis |
+| 1 | **`01-FlowHub_Arc42.pdf`** — Architektur (as built) | 24 | 12 arc42-Kapitel, 9 Diagramme (System-Kontext, Bausteine, Lebenszyklus, Sequenzen, ER) |
+| 2 | **`02-FlowHub_Reflexion.pdf`** | 7 | KI-Werkzeuge, Workflow-Entwicklung Block 1→5, Stärken/Fehlerquellen, Fazit |
+| 3 | **`03-FlowHub_Praesentation.pdf`** | 18 | Foliensatz: Teil 1 Produkt, Teil 2 Bauen mit KI |
+| 4 | **`04-FlowHub_Eigenstaendigkeitserklaerung.pdf`** | 2 | Hilfsmittelverzeichnis + unterschriebene Erklärung |
 
 ### Weitere Dokumente im Repository (verlinkt, nicht separat hochgeladen)
 

--- a/docs/project/submission-notes.md
+++ b/docs/project/submission-notes.md
@@ -107,10 +107,12 @@ The signature applies to the **separate `Eigenständigkeitserklärung.pdf`**. Pi
 
 ### F — Upload to Moodle (T-0, before 2026-07-04 24:00)
 
+- [ ] Run `just package-submission` → assembles the numbered set into `./upload/`:
+      `00-FlowHub_Uebersicht.pdf` · `01-FlowHub_Arc42.pdf` · `02-FlowHub_Reflexion.pdf` ·
+      `03-FlowHub_Praesentation.pdf` · `04-FlowHub_Eigenstaendigkeitserklaerung.pdf`
+- [ ] **Sign** `04-FlowHub_Eigenstaendigkeitserklaerung.pdf` (overwrite in `./upload/`)
 - [ ] Log into FFHS Moodle → *PVA FS26 → Deployment & Abgabe Projektarbeit*
-- [ ] Upload the **5 files**: `FlowHub_Uebersicht.pdf` · `FlowHub_Arc42_v2.pdf` ·
-      `FlowHub_Reflexion.pdf` · `flowhub-praesentation.pdf` ·
-      `Eigenständigkeitserklärung.pdf` (**signed**)
+- [ ] Upload the **5 files** from `./upload/` (the `00–04` prefixes keep them in reading order)
 - [ ] Confirm — Moodle shows all 5 files and a submission timestamp
 - [ ] Screenshot the confirmation (fallback proof)
 
@@ -124,10 +126,8 @@ The signature applies to the **separate `Eigenständigkeitserklärung.pdf`**. Pi
 ### Pre-flight quick check
 
 ```bash
-just build && just test && \
-  just pdf-submission && just pdf-arc42 && just pdf-reflexion && \
-  just pdf-eigenstaendigkeitserklaerung && \
-  echo "Pre-flight OK — sign Eigenständigkeitserklärung.pdf, then upload the 5 files"
+just build && just test && just package-submission && \
+  echo "Pre-flight OK — sign ./upload/04-*.pdf, then upload all 5 from ./upload/"
 ```
 
 ## Outputs are gitignored (or tracked)

--- a/justfile
+++ b/justfile
@@ -648,6 +648,20 @@ pdf-submission-bundle:
     tools/submission-bundle.sh tools/build/submission-bundle.md
     node {{pdf_renderer}} tools/build/submission-bundle.md SUBMISSION-bundle.pdf --title "FlowHub — CAS AISE Submission Bundle"
 
+# Assemble the numbered Moodle upload set (00–04) into ./upload/
+[group('pdf')]
+package-submission: pdf-submission pdf-arc42 pdf-reflexion pdf-eigenstaendigkeitserklaerung
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p upload
+    cp FlowHub_Uebersicht.pdf                       upload/00-FlowHub_Uebersicht.pdf
+    cp docs/architektur/FlowHub_Arc42_v2.pdf        upload/01-FlowHub_Arc42.pdf
+    cp docs/reflexion/FlowHub_Reflexion.pdf         upload/02-FlowHub_Reflexion.pdf
+    cp docs/presentation/flowhub-praesentation.pdf  upload/03-FlowHub_Praesentation.pdf
+    cp "Eigenständigkeitserklärung.pdf"             upload/04-FlowHub_Eigenstaendigkeitserklaerung.pdf
+    echo "Upload set ready in ./upload/ (00–04). Sign 04 before uploading."
+    ls -1 upload/
+
 # Build Eigenständigkeitserklärung.pdf (FFHS Hilfsmittelverzeichnis + signed declaration; compact layout)
 [group('pdf')]
 pdf-eigenstaendigkeitserklaerung:


### PR DESCRIPTION
Adds sortable numeric prefixes to the Moodle upload set so the 5 files appear in reading order.

- **`just package-submission`** assembles the upload PDFs into `./upload/`: `00-FlowHub_Uebersicht` · `01-FlowHub_Arc42` · `02-FlowHub_Reflexion` · `03-FlowHub_Praesentation` · `04-FlowHub_Eigenstaendigkeitserklaerung`.
- Hub Dokumentenübersicht + Hinweis show the numbered filenames.
- submission-notes upload/pre-flight steps use the new recipe.
- `.gitignore`: ignore `./upload/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)