### PR TITLE
docs(submission): underscore prefix (00_) for upload set — survives download

### DIFF
--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -9,7 +9,7 @@
 
 ## Hinweis zum Aufbau dieses Dokuments
 
-Diese Datei (`00-FlowHub_Uebersicht.pdf`) ist der **Einstieg in die Abgabe**: Sie beginnt mit der Dokumentenübersicht und enthält danach eine kurze Projektzusammenfassung sowie ein klickbares Inhaltsverzeichnis aller Artefakte. Die vollständigen Inhalte liegen im verlinkten GitHub-Repository; sämtliche Links zeigen auf den `main`-Branch und sind aus dem PDF heraus klickbar.
+Diese Datei (`00_FlowHub_Uebersicht.pdf`) ist der **Einstieg in die Abgabe**: Sie beginnt mit der Dokumentenübersicht und enthält danach eine kurze Projektzusammenfassung sowie ein klickbares Inhaltsverzeichnis aller Artefakte. Die vollständigen Inhalte liegen im verlinkten GitHub-Repository; sämtliche Links zeigen auf den `main`-Branch und sind aus dem PDF heraus klickbar.
 
 ---
 
@@ -19,11 +19,11 @@ Diese Datei (`00-FlowHub_Uebersicht.pdf`) ist der **Einstieg in die Abgabe**: Si
 
 | # | Dokument | Seiten | Inhalt |
 |---|---|---:|---|
-| 0 | **`00-FlowHub_Uebersicht.pdf`** *(diese Datei)* | 8 | Einstieg: Dokumentenübersicht + Projektzusammenfassung + klickbares Inhaltsverzeichnis |
-| 1 | **`01-FlowHub_Arc42.pdf`** — Architektur (as built) | 24 | 12 arc42-Kapitel, 9 Diagramme (System-Kontext, Bausteine, Lebenszyklus, Sequenzen, ER) |
-| 2 | **`02-FlowHub_Reflexion.pdf`** | 7 | KI-Werkzeuge, Workflow-Entwicklung Block 1→5, Stärken/Fehlerquellen, Fazit |
-| 3 | **`03-FlowHub_Praesentation.pdf`** | 18 | Foliensatz: Teil 1 Produkt, Teil 2 Bauen mit KI |
-| 4 | **`04-FlowHub_Eigenstaendigkeitserklaerung.pdf`** | 2 | Hilfsmittelverzeichnis + unterschriebene Erklärung |
+| 0 | **`00_FlowHub_Uebersicht.pdf`** *(diese Datei)* | 8 | Einstieg: Dokumentenübersicht + Projektzusammenfassung + klickbares Inhaltsverzeichnis |
+| 1 | **`01_FlowHub_Arc42.pdf`** — Architektur (as built) | 24 | 12 arc42-Kapitel, 9 Diagramme (System-Kontext, Bausteine, Lebenszyklus, Sequenzen, ER) |
+| 2 | **`02_FlowHub_Reflexion.pdf`** | 7 | KI-Werkzeuge, Workflow-Entwicklung Block 1→5, Stärken/Fehlerquellen, Fazit |
+| 3 | **`03_FlowHub_Praesentation.pdf`** | 18 | Foliensatz: Teil 1 Produkt, Teil 2 Bauen mit KI |
+| 4 | **`04_FlowHub_Eigenstaendigkeitserklaerung.pdf`** | 2 | Hilfsmittelverzeichnis + unterschriebene Erklärung |
 
 ### Weitere Dokumente im Repository (verlinkt, nicht separat hochgeladen)
 

--- a/docs/project/submission-notes.md
+++ b/docs/project/submission-notes.md
@@ -108,9 +108,9 @@ The signature applies to the **separate `Eigenständigkeitserklärung.pdf`**. Pi
 ### F — Upload to Moodle (T-0, before 2026-07-04 24:00)
 
 - [ ] Run `just package-submission` → assembles the numbered set into `./upload/`:
-      `00-FlowHub_Uebersicht.pdf` · `01-FlowHub_Arc42.pdf` · `02-FlowHub_Reflexion.pdf` ·
-      `03-FlowHub_Praesentation.pdf` · `04-FlowHub_Eigenstaendigkeitserklaerung.pdf`
-- [ ] **Sign** `04-FlowHub_Eigenstaendigkeitserklaerung.pdf` (overwrite in `./upload/`)
+      `00_FlowHub_Uebersicht.pdf` · `01_FlowHub_Arc42.pdf` · `02_FlowHub_Reflexion.pdf` ·
+      `03_FlowHub_Praesentation.pdf` · `04_FlowHub_Eigenstaendigkeitserklaerung.pdf`
+- [ ] **Sign** `04_FlowHub_Eigenstaendigkeitserklaerung.pdf` (overwrite in `./upload/`)
 - [ ] Log into FFHS Moodle → *PVA FS26 → Deployment & Abgabe Projektarbeit*
 - [ ] Upload the **5 files** from `./upload/` (the `00–04` prefixes keep them in reading order)
 - [ ] Confirm — Moodle shows all 5 files and a submission timestamp

--- a/justfile
+++ b/justfile
@@ -654,11 +654,12 @@ package-submission: pdf-submission pdf-arc42 pdf-reflexion pdf-eigenstaendigkeit
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p upload
-    cp FlowHub_Uebersicht.pdf                       upload/00-FlowHub_Uebersicht.pdf
-    cp docs/architektur/FlowHub_Arc42_v2.pdf        upload/01-FlowHub_Arc42.pdf
-    cp docs/reflexion/FlowHub_Reflexion.pdf         upload/02-FlowHub_Reflexion.pdf
-    cp docs/presentation/flowhub-praesentation.pdf  upload/03-FlowHub_Praesentation.pdf
-    cp "Eigenständigkeitserklärung.pdf"             upload/04-FlowHub_Eigenstaendigkeitserklaerung.pdf
+    rm -f upload/*.pdf
+    cp FlowHub_Uebersicht.pdf                       upload/00_FlowHub_Uebersicht.pdf
+    cp docs/architektur/FlowHub_Arc42_v2.pdf        upload/01_FlowHub_Arc42.pdf
+    cp docs/reflexion/FlowHub_Reflexion.pdf         upload/02_FlowHub_Reflexion.pdf
+    cp docs/presentation/flowhub-praesentation.pdf  upload/03_FlowHub_Praesentation.pdf
+    cp "Eigenständigkeitserklärung.pdf"             upload/04_FlowHub_Eigenstaendigkeitserklaerung.pdf
     echo "Upload set ready in ./upload/ (00–04). Sign 04 before uploading."
     ls -1 upload/
 


### PR DESCRIPTION
The `-` in `00-FlowHub_…` got stripped on download. Switch the `package-submission` counter separator to **underscore** (`00_FlowHub_Uebersicht` … `04_FlowHub_Eigenstaendigkeitserklaerung`), which behaves like the rest of the filename and survives. Recipe now also clears `./upload/` per run. Hub Dokumentenübersicht + submission-notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)