### PR TITLE
fix(web): soften Unhandled capture copy so it doesn't read as a crash

### DIFF
--- a/source/FlowHub.Web/Components/Pages/CaptureDetail.razor
+++ b/source/FlowHub.Web/Components/Pages/CaptureDetail.razor
@@ -70,9 +70,26 @@ else
             }
             else if (_capture.Stage == LifecycleStage.Unhandled)
             {
-                <MudAlert Severity="Severity.Error" Class="mb-4">
-                    Skill integration failed: @(_capture.FailureReason ?? "Unknown error")
-                </MudAlert>
+                @* Unhandled ≠ crash: either no skill matched, or the matched skill has no
+                   configured integration. Only show a hard failure when there's an actual reason. *@
+                @if (!string.IsNullOrWhiteSpace(_capture.FailureReason))
+                {
+                    <MudAlert Severity="Severity.Warning" Class="mb-4">
+                        Not routed: @_capture.FailureReason
+                    </MudAlert>
+                }
+                else if (string.IsNullOrWhiteSpace(_capture.MatchedSkill))
+                {
+                    <MudAlert Severity="Severity.Info" Class="mb-4">
+                        No matching skill — this capture wasn't routed to any integration. Assign a skill or ignore it.
+                    </MudAlert>
+                }
+                else
+                {
+                    <MudAlert Severity="Severity.Info" Class="mb-4">
+                        No <strong>@_capture.MatchedSkill</strong> integration is configured, so this capture wasn't routed. Assign a skill or ignore it.
+                    </MudAlert>
+                }
             }
 
             @* Content *@

--- a/tests/FlowHub.Web.ComponentTests/Pages/CaptureDetailTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/Pages/CaptureDetailTests.cs
@@ -89,7 +89,7 @@ public class CaptureDetailTests : TestContext
     }
 
     [Fact]
-    public void Render_Unhandled_ShowsIntegrationFailedAlertAndAssignButton()
+    public void Render_Unhandled_WithReason_ShowsNotRoutedAlertAndAssignButton()
     {
         var id = Guid.NewGuid();
         _captureService.GetByIdAsync(id, Arg.Any<CancellationToken>())
@@ -98,10 +98,28 @@ public class CaptureDetailTests : TestContext
 
         var cut = RenderComponent<CaptureDetail>(p => p.Add(c => c.Id, id));
 
-        cut.Markup.Should().Contain("Skill integration failed");
+        cut.Markup.Should().Contain("Not routed");
         cut.Markup.Should().Contain("wallabag 503");
         cut.Markup.Should().Contain("Assign skill");
         cut.Markup.Should().NotContain("Retry routing");
+    }
+
+    [Fact]
+    public void Render_Unhandled_NoSkillNoReason_ShowsNoMatchingSkillNotUnknownError()
+    {
+        // Regression: an Unhandled capture with neither a matched skill nor a failure reason
+        // (e.g. the demo's seeded file-upload fixture) must not read as a crash.
+        var id = Guid.NewGuid();
+        _captureService.GetByIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new Capture(id, ChannelKind.Web, "Scanned receipt", DateTimeOffset.UtcNow,
+                LifecycleStage.Unhandled, MatchedSkill: null, FailureReason: null));
+
+        var cut = RenderComponent<CaptureDetail>(p => p.Add(c => c.Id, id));
+
+        cut.Markup.Should().Contain("No matching skill");
+        cut.Markup.Should().NotContain("Skill integration failed");
+        cut.Markup.Should().NotContain("Unknown error");
+        cut.Markup.Should().Contain("Assign skill");
     }
 
     [Fact]

--- a/tests/FlowHub.Web.ComponentTests/SmokeTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/SmokeTests.cs
@@ -153,12 +153,18 @@ public class SmokeTests : TestContext
 
         var cut = RenderComponent<CaptureDetail>(p => p.Add(c => c.Id, unhandled.Id));
 
-        // Failure alert surfaces FailureReason (Beta MVP — Unhandled means a skill matched but
-        // its integration failed; the operator drills in here to read the reason).
-        cut.Markup.Should().Contain("Skill integration failed");
+        // Unhandled alert explains why the capture wasn't routed. When a FailureReason exists it
+        // is surfaced ("Not routed: …"); otherwise the alert states no skill matched (the stub's
+        // Unhandled fixture has neither a matched skill nor a reason) — never a bare "Unknown error".
+        cut.Markup.Should().NotContain("Unknown error");
         if (!string.IsNullOrWhiteSpace(unhandled.FailureReason))
         {
+            cut.Markup.Should().Contain("Not routed");
             cut.Markup.Should().Contain(unhandled.FailureReason);
+        }
+        else
+        {
+            cut.Markup.Should().Contain("No matching skill");
         }
 
         // Full content

--- a/tests/FlowHub.Web.E2ETests/Journeys/J17.json
+++ b/tests/FlowHub.Web.E2ETests/Journeys/J17.json
@@ -1,7 +1,7 @@
 {
   "id": "J17",
   "category": "functional",
-  "description": "An Unhandled capture shows the integration failure and offers Assign skill + Ignore (no Retry routing)",
+  "description": "An Unhandled capture explains why it wasn't routed and offers Assign skill + Ignore (no Retry routing)",
   "entryUrl": "/captures",
   "preconditions": ["At least one Unhandled-stage capture exists"],
   "steps": [
@@ -9,7 +9,7 @@
     "Click the first row whose lifecycle badge reads 'unhandled'"
   ],
   "expected": [
-    "Error alert containing 'Skill integration failed' is visible",
+    "Alert containing 'No matching skill' is visible",
     "Button 'Assign skill' is present",
     "Button 'Retry routing' is NOT present"
   ],

--- a/tests/FlowHub.Web.E2ETests/Journeys/J17_CaptureDetailUnhandledActions.cs
+++ b/tests/FlowHub.Web.E2ETests/Journeys/J17_CaptureDetailUnhandledActions.cs
@@ -16,7 +16,7 @@ public sealed class J17_CaptureDetailUnhandledActions : JourneyTestBase
         await row.WaitForAsync(new LocatorWaitForOptions { Timeout = 15_000 });
         await row.ClickAsync();
 
-        await Page.Locator(".mud-alert", new PageLocatorOptions { HasText = "Skill integration failed" })
+        await Page.Locator(".mud-alert", new PageLocatorOptions { HasText = "No matching skill" })
             .First.WaitForAsync(new LocatorWaitForOptions { Timeout = 15_000 });
 
         (await Page.GetByText("Assign skill").CountAsync()).Should().BeGreaterThan(0);


### PR DESCRIPTION
## Problem

A demo tester reported the seeded file-upload fixture (`Receipt — Migros`) as a crash. The capture detail page rendered:

> **Skill integration failed: Unknown error**

That reads like an unhandled exception, but nothing threw — it's an Unhandled-stage capture with a `NULL` `FailureReason`, so the UI fell back to the generic `"Unknown error"` string (`CaptureDetail.razor`). `Unhandled` doesn't even necessarily mean a failure: it can mean *no skill matched* or *the matched skill has no configured integration* (e.g. Paperless is intentionally unwired on the public demo).

## Change

`CaptureDetail` now picks copy by state instead of always saying "integration failed":

| State | Copy | Severity |
|---|---|---|
| `FailureReason` present | `Not routed: <reason>` | Warning |
| No matched skill | `No matching skill — … assign a skill or ignore it.` | Info |
| Skill, no integration | `No <skill> integration is configured, so this capture wasn't routed. …` | Info |

No more bare "Unknown error". This is the previously-deferred "Unhandled-copy softening" item; the demo tester's confusion is what made it worth doing now.

## Tests

- Updated component (`CaptureDetailTests`, `SmokeTests`) and E2E (`J17`) assertions to the new copy.
- Added a regression test for the no-skill/no-reason case (asserts `No matching skill`, **not** `Skill integration failed` / `Unknown error`).
- `FlowHub.Web.ComponentTests`: **182 passed, 0 failed**.

No seed data changed — the fix is at the UI layer so it covers every no-reason Unhandled capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)