### PR TITLE
fix(docker): copy CodeMetricsConfig.txt into build image

### DIFF
--- a/docker/migrations/Dockerfile
+++ b/docker/migrations/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /src
 
-COPY FlowHub.slnx Directory.Build.props Directory.Packages.props global.json .editorconfig ./
+COPY FlowHub.slnx Directory.Build.props Directory.Packages.props CodeMetricsConfig.txt global.json .editorconfig ./
 COPY source/ ./source/
 COPY tests/ ./tests/
 

--- a/source/FlowHub.Web/Dockerfile
+++ b/source/FlowHub.Web/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /src
 
 # Copy solution files first for layer caching
-COPY FlowHub.slnx Directory.Build.props Directory.Packages.props global.json .editorconfig ./
+COPY FlowHub.slnx Directory.Build.props Directory.Packages.props CodeMetricsConfig.txt global.json .editorconfig ./
 COPY source/ ./source/
 COPY tests/ ./tests/
 


### PR DESCRIPTION
#99 added `<AdditionalFiles Include="…/CodeMetricsConfig.txt">` to `Directory.Build.props`, but the Dockerfiles copy the props without the file, so `dotnet publish` fails with **CS2001 (file not found)** in the image build. CI builds/tests but doesn't build the Docker image, so it slipped through — and it blocks the demo redeploy.

Fix: add `CodeMetricsConfig.txt` to the `COPY` line in the web + migrations Dockerfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)