### PR TITLE
fix(quality): reduce Program.cs complexity, re-promote CA1502 to error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ dotnet_diagnostic.CA1825.severity = none
 # --- .NET quality gates (seeded from ai-instructions/templates/dotnet) ---
 # Thresholds for CA1502/CA1506 live in CodeMetricsConfig.txt (single source).
 [*.cs]
-dotnet_diagnostic.CA1502.severity = warning  # cyclomatic complexity (Phase-1 debt, see Directory.Build.props)
+dotnet_diagnostic.CA1502.severity = error    # excessive cyclomatic complexity
 dotnet_diagnostic.CA1506.severity = warning  # excessive class coupling (Phase-1 debt, see Directory.Build.props)
 dotnet_diagnostic.IDE0005.severity = error   # unnecessary using directive
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,10 +7,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <!-- debt: demoted to warnings so Phase-1 CI is green; ratchet back to errors.
+    <!-- debt: demoted to a warning so CI is green; ratchet back to an error.
          CA1506 (class coupling, 104 violations) -> #95.
-         CA1502 (Program.cs Main complexity) -> #97. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1502;CA1506</WarningsNotAsErrors>
+         (CA1502 was re-promoted to an error in #97.) -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1506</WarningsNotAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <Version>0.2.0</Version>

--- a/source/FlowHub.Web/Program.cs
+++ b/source/FlowHub.Web/Program.cs
@@ -3,14 +3,9 @@ using FlowHub.Api;
 using FlowHub.Api.Endpoints;
 using FlowHub.Persistence;
 using FlowHub.Skills;
-using FlowHub.Web.Auth;
+using FlowHub.Web;
 using FlowHub.Web.Components;
-using FlowHub.Web.Notifications;
-using FlowHub.Web.Pipeline;
 using FlowHub.Web.Testing;
-using MassTransit;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using MudBlazor.Services;
 using OpenTelemetry.Metrics;
 using Scalar.AspNetCore;
@@ -25,56 +20,8 @@ builder.Services
 // MudBlazor — only component library per CLAUDE.md.
 builder.Services.AddMudServices();
 
-// Auth mode is driven by configuration, not environment name (12-Factor III).
-// Set Auth__OIDC__Authority + Auth__OIDC__ClientId + Auth__OIDC__ClientSecret for real OIDC.
-// Omit all Auth__OIDC__* vars to activate DemoAuthHandler (any environment).
-if (builder.Configuration["Auth:OIDC:Authority"] is { Length: > 0 } oidcAuthority)
-{
-    var clientId = builder.Configuration["Auth:OIDC:ClientId"]
-        ?? throw new InvalidOperationException("Auth:OIDC:ClientId is required when Auth:OIDC:Authority is set.");
-    var clientSecret = builder.Configuration["Auth:OIDC:ClientSecret"]
-        ?? throw new InvalidOperationException("Auth:OIDC:ClientSecret is required when Auth:OIDC:Authority is set.");
-
-    // Policy scheme dispatches per request: bearer token → JwtBearer (API clients get 401),
-    // anything else → cookie+OIDC (browser flow gets 302 redirect).
-    const string SmartScheme = "smart";
-    builder.Services
-        .AddAuthentication(options =>
-        {
-            options.DefaultScheme = SmartScheme;
-            options.DefaultChallengeScheme = SmartScheme;
-        })
-        .AddPolicyScheme(SmartScheme, SmartScheme, options =>
-        {
-            options.ForwardDefaultSelector = ctx =>
-                ctx.Request.Headers.Authorization.ToString()
-                    .StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-                    ? JwtBearerDefaults.AuthenticationScheme
-                    : Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme;
-        })
-        .AddCookie()
-        .AddJwtBearer(options =>
-        {
-            options.Authority = oidcAuthority;
-            options.Audience = clientId;
-            options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
-        })
-        .AddOpenIdConnect(options =>
-        {
-            options.Authority = oidcAuthority;
-            options.ClientId = clientId;
-            options.ClientSecret = clientSecret;
-            options.ResponseType = "code";
-            options.SaveTokens = true;
-        });
-}
-else
-{
-    builder.Services
-        .AddAuthentication(DemoAuthHandler.SchemeName)
-        .AddScheme<AuthenticationSchemeOptions, DemoAuthHandler>(DemoAuthHandler.SchemeName, _ => { });
-}
-
+// Configuration-driven auth (real OIDC vs demo handler) — see ProgramRegistration.
+builder.AddFlowHubAuthentication();
 builder.Services.AddAuthorization();
 builder.Services.AddCascadingAuthenticationState();
 
@@ -119,62 +66,11 @@ builder.Services.AddFlowHubSkills(builder.Configuration);
 builder.Services.Configure<FlowHub.Web.Demo.DemoTraceOptions>(
     builder.Configuration.GetSection(FlowHub.Web.Demo.DemoTraceOptions.SectionName));
 
-// Demo-only operator notifications → ntfy.sh. Dormant unless Demo:Notify:Ntfy:BaseUrl + Topic
-// are set, so the normal app / agent-dev trial never call out. ntfy → Telegram is bridged at
-// the ntfy layer, keeping FlowHub transport-agnostic.
-var demoNotify = builder.Configuration.GetSection(DemoNotifyOptions.SectionName).Get<DemoNotifyOptions>()
-    ?? new DemoNotifyOptions();
-var demoNotifyEnabled = demoNotify.IsConfigured;
-if (demoNotifyEnabled)
-{
-    builder.Services.Configure<DemoNotifyOptions>(builder.Configuration.GetSection(DemoNotifyOptions.SectionName));
-    builder.Services.AddHttpClient<ICaptureNotifier, NtfyCaptureNotifier>(client =>
-    {
-        client.BaseAddress = new Uri(demoNotify.BaseUrl!.TrimEnd('/') + "/");
-        client.Timeout = TimeSpan.FromSeconds(10);
-    });
-}
+// Demo-only operator notifications → ntfy.sh (dormant unless configured) — see ProgramRegistration.
+var demoNotifyEnabled = builder.AddFlowHubDemoNotifications();
 
-// Block 3 Slice B — MassTransit pipeline.
-builder.Services.AddMassTransit(x =>
-{
-    x.SetKebabCaseEndpointNameFormatter();
-
-    x.AddConsumer<CaptureEnrichmentConsumer>(c =>
-        c.UseMessageRetry(r => r.Intervals(100, 500)));
-
-    x.AddConsumer<CaptureEmbeddingConsumer>(c =>
-        c.UseMessageRetry(r => r.Intervals(500, 2000, 5000)));
-
-    x.AddConsumer<SkillRoutingConsumer>(c =>
-        c.UseMessageRetry(r => r.Intervals(500, 2000, 5000)));
-
-    // No retry policy — fault observer is best-effort per spec D5
-    // (recursive retry on Fault<T> would loop forever).
-    x.AddConsumer<LifecycleFaultObserver>();
-
-    // Demo-only: announce new captures to ntfy.sh (registered only when configured).
-    if (demoNotifyEnabled)
-        x.AddConsumer<CaptureNotificationConsumer>(c =>
-            c.UseMessageRetry(r => r.Intervals(500, 2000)));
-
-    if (string.Equals(builder.Configuration["Bus:Transport"], "RabbitMq", StringComparison.OrdinalIgnoreCase))
-    {
-        x.UsingRabbitMq((ctx, cfg) =>
-        {
-            cfg.Host(builder.Configuration["Bus:RabbitMq:Host"], "/", h =>
-            {
-                h.Username(builder.Configuration["Bus:RabbitMq:Username"] ?? "guest");
-                h.Password(builder.Configuration["Bus:RabbitMq:Password"] ?? "guest");
-            });
-            cfg.ConfigureEndpoints(ctx);
-        });
-    }
-    else
-    {
-        x.UsingInMemory((ctx, cfg) => cfg.ConfigureEndpoints(ctx));
-    }
-});
+// Block 3 Slice B — MassTransit pipeline (consumers, retries, transport) — see ProgramRegistration.
+builder.AddFlowHubMessaging(demoNotifyEnabled);
 
 // Block 3 Slice A — REST API surface for non-UI consumers.
 builder.Services.AddFlowHubApi();

--- a/source/FlowHub.Web/ProgramRegistration.cs
+++ b/source/FlowHub.Web/ProgramRegistration.cs
@@ -1,0 +1,145 @@
+using FlowHub.Web.Auth;
+using FlowHub.Web.Notifications;
+using FlowHub.Web.Pipeline;
+using MassTransit;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace FlowHub.Web;
+
+/// <summary>
+/// Service-registration helpers extracted from Program.cs so the top-level
+/// entry point stays under the CA1502 cyclomatic-complexity gate. Each method
+/// preserves the original registration order and behaviour.
+/// </summary>
+internal static class ProgramRegistration
+{
+    /// <summary>
+    /// Configuration-driven auth: real OIDC when <c>Auth:OIDC:Authority</c> is
+    /// set (smart policy scheme dispatches bearer → JWT, browser → cookie+OIDC),
+    /// otherwise the demo handler. Auth mode is driven by config, not environment
+    /// name (12-Factor III).
+    /// </summary>
+    public static void AddFlowHubAuthentication(this WebApplicationBuilder builder)
+    {
+        if (builder.Configuration["Auth:OIDC:Authority"] is { Length: > 0 } oidcAuthority)
+        {
+            var clientId = builder.Configuration["Auth:OIDC:ClientId"]
+                ?? throw new InvalidOperationException("Auth:OIDC:ClientId is required when Auth:OIDC:Authority is set.");
+            var clientSecret = builder.Configuration["Auth:OIDC:ClientSecret"]
+                ?? throw new InvalidOperationException("Auth:OIDC:ClientSecret is required when Auth:OIDC:Authority is set.");
+
+            // Policy scheme dispatches per request: bearer token → JwtBearer (API clients get 401),
+            // anything else → cookie+OIDC (browser flow gets 302 redirect).
+            const string SmartScheme = "smart";
+            builder.Services
+                .AddAuthentication(options =>
+                {
+                    options.DefaultScheme = SmartScheme;
+                    options.DefaultChallengeScheme = SmartScheme;
+                })
+                .AddPolicyScheme(SmartScheme, SmartScheme, options =>
+                {
+                    options.ForwardDefaultSelector = ctx =>
+                        ctx.Request.Headers.Authorization.ToString()
+                            .StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                            ? JwtBearerDefaults.AuthenticationScheme
+                            : Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme;
+                })
+                .AddCookie()
+                .AddJwtBearer(options =>
+                {
+                    options.Authority = oidcAuthority;
+                    options.Audience = clientId;
+                    options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+                })
+                .AddOpenIdConnect(options =>
+                {
+                    options.Authority = oidcAuthority;
+                    options.ClientId = clientId;
+                    options.ClientSecret = clientSecret;
+                    options.ResponseType = "code";
+                    options.SaveTokens = true;
+                });
+        }
+        else
+        {
+            builder.Services
+                .AddAuthentication(DemoAuthHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, DemoAuthHandler>(DemoAuthHandler.SchemeName, _ => { });
+        }
+    }
+
+    /// <summary>
+    /// Demo-only operator notifications → ntfy.sh. Dormant unless
+    /// <c>Demo:Notify:Ntfy:BaseUrl</c> + Topic are set. Returns whether the demo
+    /// notifier was registered, so messaging can wire its consumer to match.
+    /// </summary>
+    public static bool AddFlowHubDemoNotifications(this WebApplicationBuilder builder)
+    {
+        var demoNotify = builder.Configuration.GetSection(DemoNotifyOptions.SectionName).Get<DemoNotifyOptions>()
+            ?? new DemoNotifyOptions();
+        if (!demoNotify.IsConfigured)
+        {
+            return false;
+        }
+
+        builder.Services.Configure<DemoNotifyOptions>(builder.Configuration.GetSection(DemoNotifyOptions.SectionName));
+        builder.Services.AddHttpClient<ICaptureNotifier, NtfyCaptureNotifier>(client =>
+        {
+            client.BaseAddress = new Uri(demoNotify.BaseUrl!.TrimEnd('/') + "/");
+            client.Timeout = TimeSpan.FromSeconds(10);
+        });
+        return true;
+    }
+
+    /// <summary>
+    /// Block 3 Slice B — MassTransit pipeline (consumers + retry policies +
+    /// transport selection). The demo notification consumer is added only when
+    /// <paramref name="demoNotifyEnabled"/>.
+    /// </summary>
+    public static void AddFlowHubMessaging(this WebApplicationBuilder builder, bool demoNotifyEnabled)
+    {
+        builder.Services.AddMassTransit(x =>
+        {
+            x.SetKebabCaseEndpointNameFormatter();
+
+            x.AddConsumer<CaptureEnrichmentConsumer>(c =>
+                c.UseMessageRetry(r => r.Intervals(100, 500)));
+
+            x.AddConsumer<CaptureEmbeddingConsumer>(c =>
+                c.UseMessageRetry(r => r.Intervals(500, 2000, 5000)));
+
+            x.AddConsumer<SkillRoutingConsumer>(c =>
+                c.UseMessageRetry(r => r.Intervals(500, 2000, 5000)));
+
+            // No retry policy — fault observer is best-effort per spec D5
+            // (recursive retry on Fault<T> would loop forever).
+            x.AddConsumer<LifecycleFaultObserver>();
+
+            // Demo-only: announce new captures to ntfy.sh (registered only when configured).
+            if (demoNotifyEnabled)
+            {
+                x.AddConsumer<CaptureNotificationConsumer>(c =>
+                    c.UseMessageRetry(r => r.Intervals(500, 2000)));
+            }
+
+            if (string.Equals(builder.Configuration["Bus:Transport"], "RabbitMq", StringComparison.OrdinalIgnoreCase))
+            {
+                x.UsingRabbitMq((ctx, cfg) =>
+                {
+                    cfg.Host(builder.Configuration["Bus:RabbitMq:Host"], "/", h =>
+                    {
+                        h.Username(builder.Configuration["Bus:RabbitMq:Username"] ?? "guest");
+                        h.Password(builder.Configuration["Bus:RabbitMq:Password"] ?? "guest");
+                    });
+                    cfg.ConfigureEndpoints(ctx);
+                });
+            }
+            else
+            {
+                x.UsingInMemory((ctx, cfg) => cfg.ConfigureEndpoints(ctx));
+            }
+        });
+    }
+}

--- a/tools/verify-gates.sh
+++ b/tools/verify-gates.sh
@@ -9,11 +9,11 @@
 # *inside* FlowHub's tree (so they inherit FlowHub's Directory.Build.props /
 # .editorconfig) and asserts each ENFORCED gate fires.
 #
-# Phase-1 note (issue #94): CA1502/CA1506 are demoted to warnings here (debt,
-# #95/#97), so this checks the gates FlowHub currently ENFORCES: IDE0005 (build
-# error) and the method-size check. Re-add CA1502/CA1506 below when Phase-2
-# re-promotes them. (The method-size action step is deferred on Linux —
-# agent-pipeline#91 — but the check script itself is Linux-safe and verified here.)
+# Enforced gates checked here: CA1502 (re-promoted in #97), IDE0005, and the
+# method-size check. CA1506 is still demoted to a warning (debt #95) so it is not
+# asserted as a build-failure yet — add it below when #95 re-promotes it. (The
+# method-size action step is deferred on Linux — agent-pipeline#91 — but the
+# check script itself is Linux-safe and verified here.)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -42,6 +42,17 @@ if dotnet build "${SCRATCH}/ide/UnusedUsing.csproj" -c Release --nologo -v q >/d
   fail=1
 else
   printf 'OK: IDE0005 fired\n'
+fi
+
+# --- CA1502: re-promoted to an error in #97 ----------------------------------
+note "CA1502 fixture must FAIL the build under FlowHub's resolved config"
+fetch "gate-tests/build-failures/Complexity/Complexity.cs"     "ca1502/Complexity.cs"
+fetch "gate-tests/build-failures/Complexity/Complexity.csproj" "ca1502/Complexity.csproj"
+if dotnet build "${SCRATCH}/ca1502/Complexity.csproj" -c Release --nologo -v q >/dev/null 2>&1; then
+  printf '::error::CA1502 did NOT fail the build — the gate is dead in FlowHub\n'
+  fail=1
+else
+  printf 'OK: CA1502 fired\n'
 fi
 
 # --- Method-size check (Linux-safe; independent of the Metrics.exe generator) -


### PR DESCRIPTION
Closes #97 (Phase-2 ratchet).

Extracts the branchy DI-registration blocks (auth, demo notifications, MassTransit) from `Program.cs` into `ProgramRegistration` extension methods, dropping `<Main>$` cyclomatic complexity below the CA1502 threshold of 10. **CA1502 is re-promoted to an error** (removed from `WarningsNotAsErrors`; `.editorconfig` severity = error), and `verify-gates` now asserts the CA1502 fixture fails under FlowHub's resolved config.

Behaviour preserved — registration order unchanged; integration tests (WebApplicationFactory<Program>, 21) + core unit tests pass locally; `verify-gates` green (IDE0005 + CA1502 + method-size).