### PR TITLE
docs(arc42): surface acceptance criteria + KI-guardrail tests (Validierung +4)

### DIFF
--- a/docs/architektur/FlowHub_Arc42_v2.md
+++ b/docs/architektur/FlowHub_Arc42_v2.md
@@ -763,6 +763,35 @@ In-Memory-Provider-Drift); Playwright für E2E; Live-KI-Tests sind trait-gegatet
 Abgabestand: **294 Offline-Tests grün, 0 Fehler, 0 übersprungen**. Volltext und
 Reconciliation-Tabelle in `docs/spec/testing-strategy.md`.
 
+**Test der KI-Anteile (Guardrails, nicht nur Trait-Gating).** Über das
+Ausschliessen der nicht-deterministischen Live-Aufrufe hinaus ist das
+*Ausfallverhalten* der KI deterministisch getestet (`AiClassifierTests`): fünf
+Fallback-Pfad-Tests prüfen, dass der `AiClassifier` bei HttpRequest-,
+TaskCanceled- und JSON-/Schema-Fehlern auf den `KeywordClassifier` zurückfällt,
+dabei `EventId 3010` (Warning) loggt und **nie eine Exception zum Aufrufer
+durchreicht**. Ergänzend prüft eine **Schema-Validierung** den `MatchedSkill`
+gegen die erlaubten Werte (`Wallabag`/`Vikunja`/leer) — eine ungültige
+Modell-Antwort wird verworfen statt geroutet. Das nicht-deterministische
+KI-Verhalten ist damit nicht bloss ausgeklammert, sondern an seinen Guardrails
+abgesichert.
+
+### 8.9 Abnahmekriterien (Überblick)
+
+Die Lösung ist gegen **50 prüfbare Abnahmekriterien** (`AC-01-…`) abgenommen —
+je Kernfunktion, jedes mit verifizierendem Test und, wo einschlägig, NfA-Bezug.
+Auszug:
+
+| Kernfunktion | Abnahmekriterium (Auszug) | NfA-Bezug | Prüfung |
+|---|---|---|---|
+| Erfassung (UI/API) | `POST /api/v1/captures` → 201, p95 < 200 ms (AC-08-1) | NfA-01 / NF-09 | `Api.IntegrationTests` · `just smoke-prod` |
+| Klassifikation & Routing | URL-Capture → `Completed`, `MatchedSkill=Wallabag`, `ExternalRef` gesetzt (AC-09-1) | — | `Skills.ContractTests` · `just test-beta` |
+| KI-Fallback (Guardrail) | ungültiger API-Key → Capture erreicht `Classified` via KeywordClassifier; `EventId 3010` geloggt; nie Exception (AC-10-1…3) | Zuverlässigkeit | `AiClassifierTests` |
+| Suche & Filter | Deep-Link `/captures?lc=Orphan` filtert korrekt; Listen-Abfrage p95 < 100 ms (AC-05-1) | NfA-01 | bUnit `CapturesListPageTests` |
+| Deployment | `docker compose up --wait` → exit 0, alle `service_healthy`; `/health/live` 200 < 30 s (AC-17-1/3) | NfA-D3 | `just smoke-prod` |
+
+Vollständiger Katalog (50 AC mit *Verified-by* und NfA-Verknüpfung):
+`docs/spec/acceptance-criteria.md`.
+
 ---
 
 ## 9. Architekturentscheidungen (ADR)


### PR DESCRIPTION
examiner-sim on the merged docs scored **Validierung 12/16** — not on substance but on **delivery channel**: the two strongest level-5 signals were repo-only, not in the uploaded PDFs (`grep AC-… upload.txt = 0`). This lifts them into the Arc42 SAD (same pattern as the use-case overview in §1.4).

## Changes (`docs/architektur/FlowHub_Arc42_v2.md`)
- **§8.8 Teststrategie** — add the **KI-guardrail test** discussion: 5 fallback-path tests (`AiClassifier` → `KeywordClassifier` on HttpRequest/TaskCanceled/JSON errors, `EventId 3010`, never throws) + `MatchedSkill` schema validation. Converts the documented *architecture* fallback into a documented *tested* guardrail (the Teststrategie level-5 anchor). → **+2**
- **§8.9 Abnahmekriterien (Überblick)** — per-Kernfunktion AC table with an **NfA column** + verifying test, pointing to the full 50-AC catalogue in `docs/spec/acceptance-criteria.md`. → **+2**

## Notes
- **`.md` only** — the Arc42 PDF (and merged `01` upload) regenerate via `just package-submission`. Committing only the source avoids a binary conflict with the open tagline PR #106 (also touches Arc42); both edit different sections of the `.md`, so they text-merge cleanly.
- Modeled effect: Validierung 12 → ~16 once rendered into the uploaded PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)