### PR TITLE
test(coverage): cover SkillsBootLogger (FlowHub.Skills 87%→94%)

### DIFF
--- a/tests/FlowHub.Skills.Tests/SkillsBootLoggerTests.cs
+++ b/tests/FlowHub.Skills.Tests/SkillsBootLoggerTests.cs
@@ -1,0 +1,44 @@
+using FlowHub.Core.Skills;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FlowHub.Skills.Tests;
+
+public sealed class SkillsBootLoggerTests
+{
+    [Fact]
+    public async Task StartAsync_WithMixedOutcomes_LogsRegisteredAndNotConfiguredThenStops()
+    {
+        // Wallabag fully configured (Registered=true) while Vikunja/Paperless stay
+        // unconfigured (Registered=false) → exercises both branches of the boot logger.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Skills:Wallabag:BaseUrl"] = "https://wallabag.example.com",
+                ["Skills:Wallabag:ClientId"] = "client-id",
+                ["Skills:Wallabag:ClientSecret"] = "client-secret",
+                ["Skills:Wallabag:Username"] = "user",
+                ["Skills:Wallabag:Password"] = "pass",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddFlowHubSkills(configuration);
+        await using var sp = services.BuildServiceProvider();
+
+        var outcomes = sp.GetServices<SkillsRegistrationOutcome>().ToList();
+        outcomes.Should().Contain(o => o.Registered);   // Wallabag
+        outcomes.Should().Contain(o => !o.Registered);  // Vikunja / Paperless
+
+        var hosted = sp.GetServices<IHostedService>().ToList();
+        hosted.Should().NotBeEmpty();
+
+        foreach (var service in hosted)
+        {
+            await service.StartAsync(CancellationToken.None);
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
Second increment of #103 (after FlowHub.Core → 100% in #110).

## What
DI-driven test for the previously-uncovered `SkillsBootLogger` (an `IHostedService`): builds the container with Wallabag fully configured (Registered) and Vikunja/Paperless unconfigured (not registered), then runs `StartAsync`/`StopAsync` — exercising both log branches.

## Result
- `SkillsBootLogger`: **0% → 100%**
- `FlowHub.Skills`: **87.0% → 94.4%** (Skills.Tests 42 → 43)

## Remaining FlowHub.Skills gaps (follow-up)
- `WallabagSkillIntegration` — SSRF `IsPublicIp` guards (loopback / IPv6-local / IPv4-private) + no-URL extraction path
- `WallabagTokenProvider` — refresh-failure log path
- `VikunjaProjectCatalog` — DTO record line

Relates to #103.