### PR TITLE
fix(quality): CA1506 cluster 2 — carve out Razor component code-behinds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,14 @@ dotnet_diagnostic.CA1506.severity = none
 [**/{ProgramRegistration,*ServiceCollectionExtensions}.cs]
 dotnet_diagnostic.CA1506.severity = none
 
+# Razor component code-behinds are UI orchestration: each component naturally
+# touches its parameters, child components, injected services, the DTOs it
+# renders, and the MudBlazor types it composes. That coupling is by design
+# (same architectural pattern as the composition root); CA1506 doesn't usefully
+# measure component quality. See issue #95.
+[**/*.razor.cs]
+dotnet_diagnostic.CA1506.severity = none
+
 # Test code is held to a looser bar (high coupling / long arrange blocks).
 [**/*Tests/**.cs]
 dotnet_diagnostic.CA1506.severity = none


### PR DESCRIPTION
Part of #95 (cluster 2). Razor code-behinds (`*.razor.cs`) are UI orchestration — each component naturally touches its parameters, child components, injected services, DTOs and MudBlazor types. That coupling is by design (same architectural pattern as the cluster-1 composition-root carve-out) and CA1506 doesn't usefully measure component quality.

## Effect
| | Before (post-cluster-1) | After |
|---|---|---|
| Unique CA1506 violations | 19 | **11** |
| Build | green (warnings) | green (warnings) |

The remaining 11 are **genuine** code-coupling refactor targets: CaptureEndpoints (63), EfCaptureRepository (49), WallabagSkillIntegration (41), VikunjaProjectCatalog (41), AiClassifier (40), WallabagTokenProvider (35), MapFlowHubApi (34), CaptureServiceStub (34), ZitateEnricher (31), ClassifyAsync (31), AdminEndpoints (31). These get refactored in cluster 3+, then CA1506 is re-promoted to error.

`verify-gates` + Core unit tests pass locally.