### PR TITLE
test(coverage): FlowHub.AI 89%→99% (boot logger + embeddings registration)

### DIFF
--- a/tests/FlowHub.Web.ComponentTests/Ai/AiBootLoggerTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/Ai/AiBootLoggerTests.cs
@@ -1,0 +1,66 @@
+using FlowHub.AI;
+using FlowHub.Core.Skills;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FlowHub.Web.ComponentTests.Ai;
+
+public sealed class AiBootLoggerTests
+{
+    [Fact]
+    public async Task StartAsync_WhenProviderConfigured_LogsRegisteredBranch_AndStops()
+    {
+        // Covers the "UsesAi=true" branch of AiBootLogger (provider + model line),
+        // which the existing "no-provider" cases skip.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ai:Provider"] = "Anthropic",
+                ["Ai:Anthropic:ApiKey"] = "sk-ant-test",
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var catalog = Substitute.For<IVikunjaProjectCatalog>();
+        catalog.GetAsync(Arg.Any<CancellationToken>())
+               .Returns(new Dictionary<string, int> { ["Inbox"] = 1 });
+        services.AddSingleton(catalog);
+        services.AddFlowHubAi(config);
+        await using var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<AiRegistrationOutcome>().UsesAi.Should().BeTrue();
+
+        var hosted = sp.GetServices<IHostedService>().OfType<AiBootLogger>().ToList();
+        hosted.Should().ContainSingle();
+
+        foreach (var service in hosted)
+        {
+            await service.StartAsync(CancellationToken.None);
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenProviderNotConfigured_LogsNotConfiguredBranch_AndStops()
+    {
+        // Sanity-cover the not-configured branch (Reason logged) end-to-end via DI,
+        // independent of the AddFlowHubAi tests that only inspect the outcome.
+        var config = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddFlowHubAi(config);
+        await using var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<AiRegistrationOutcome>().UsesAi.Should().BeFalse();
+
+        var hosted = sp.GetServices<IHostedService>().OfType<AiBootLogger>().ToList();
+        hosted.Should().ContainSingle();
+
+        foreach (var service in hosted)
+        {
+            await service.StartAsync(CancellationToken.None);
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+}

--- a/tests/FlowHub.Web.ComponentTests/Ai/AiServiceCollectionExtensionsTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/Ai/AiServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using FlowHub.AI;
+using FlowHub.Core.Captures;
 using FlowHub.Core.Classification;
 using FlowHub.Core.Skills;
 using Microsoft.Extensions.AI;
@@ -125,5 +126,61 @@ public sealed class AiServiceCollectionExtensionsTests
         });
 
         sp.GetRequiredService<AiRegistrationOutcome>().Model.Should().Be("claude-sonnet-4-7");
+    }
+
+    [Fact]
+    public void AddFlowHubEmbeddings_NoApiKey_RegistersNothing()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
+        var services = new ServiceCollection();
+
+        services.AddFlowHubEmbeddings(config);
+
+        services.Should().NotContain(d => d.ServiceType == typeof(IEmbeddingService));
+    }
+
+    [Fact]
+    public void AddFlowHubEmbeddings_WithApiKey_RegistersEmbeddingService_DefaultsToMistralEndpoint()
+    {
+        // Exercises the success path: when an API key is set, the OpenAI-compatible
+        // embedding client is wired up and AiEmbeddingService becomes resolvable.
+        // BaseUrl/Model/Dimensions defaults are accepted (Mistral, mistral-embed).
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Embeddings:ApiKey"] = "mistral-test-key",
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddFlowHubEmbeddings(config);
+
+        using var sp = services.BuildServiceProvider();
+        sp.GetService<IEmbeddingService>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddFlowHubEmbeddings_WithCustomBaseUrlAndModel_RespectsConfig()
+    {
+        // Covers the explicit-BaseUrl branch (non-empty string → used as endpoint)
+        // and the explicit Model override.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Embeddings:BaseUrl"] = "https://api.example.com/v1",
+                ["Embeddings:ApiKey"] = "test-key",
+                ["Embeddings:Model"] = "text-embedding-3-small",
+                ["Embeddings:Dimensions"] = "768",
+                ["Embeddings:TimeoutSeconds"] = "30",
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddFlowHubEmbeddings(config);
+
+        using var sp = services.BuildServiceProvider();
+        sp.GetService<IEmbeddingService>().Should().NotBeNull();
     }
 }


### PR DESCRIPTION
Fourth increment of #103.

## Tests added
- **`AiBootLogger`** — DI-resolved `IHostedService` lifecycle for both branches (UsesAi=true: logs provider+model; not-configured: logs reason). The existing extensions tests inspect the `AiRegistrationOutcome` but never exercised the boot logger's StartAsync/StopAsync.
- **`AddFlowHubEmbeddings`** — covers the success path that was entirely untested: when `Embeddings:ApiKey` is set, the OpenAI-compatible embedding client is wired up and `IEmbeddingService` resolves. Two cases — default Mistral endpoint, and explicit `BaseUrl`/`Model`/`Dimensions`/`TimeoutSeconds` overrides.

## Result
**`FlowHub.AI`: 88.8% → 99.1%** (462/466 lines, 10/10 classes).

## Documented exclusion (the 4 residual lines)
Two `_ => throw new ArgumentOutOfRangeException(...)` arms on `AiProvider` switch expressions (`DefaultModelFor`, `BuildChatClient`). The compiler requires them (CS8524 — non-exhaustive switch on enum-typed int) but they are provably unreachable at runtime: `Ai__Provider` validation already throws `InvalidOperationException` before any switch is reached. Per #103 these are the kind of justified exclusion the issue calls out.

Relates to #103.