### PR TITLE
test(coverage): FlowHub.Web phase 1 — pipeline consumers + E2E exclusions (68%→75%)

### DIFF
--- a/source/FlowHub.Web/Testing/E2EFaultExtensions.cs
+++ b/source/FlowHub.Web/Testing/E2EFaultExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FlowHub.Core.Health;
 
 namespace FlowHub.Web.Testing;
@@ -6,6 +7,10 @@ namespace FlowHub.Web.Testing;
 /// E2E-only DI hook. Activates only when <c>FLOWHUB_E2E_FAULTS_ENABLED=true</c>
 /// is set in the environment — invisible in any other deployment.
 /// </summary>
+// Excluded from coverage: by design only exercised by the E2E browser pipeline
+// (see <see cref="IsEnabled"/>); unit-testing it would test the env-var bridge,
+// not behaviour.
+[ExcludeFromCodeCoverage]
 public static class E2EFaultExtensions
 {
     public static bool IsEnabled =>

--- a/source/FlowHub.Web/Testing/FaultInjectingDecorators.cs
+++ b/source/FlowHub.Web/Testing/FaultInjectingDecorators.cs
@@ -1,7 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using FlowHub.Core.Health;
 
 namespace FlowHub.Web.Testing;
 
+// E2E test scaffolding: only active when FLOWHUB_E2E_FAULTS_ENABLED=true.
+// Excluded from coverage because exercising it requires the E2E browser pipeline.
+[ExcludeFromCodeCoverage]
 internal sealed class FaultInjectingSkillRegistry : ISkillRegistry
 {
     private readonly ISkillRegistry _inner;
@@ -23,6 +27,7 @@ internal sealed class FaultInjectingSkillRegistry : ISkillRegistry
     }
 }
 
+[ExcludeFromCodeCoverage]
 internal sealed class FaultInjectingIntegrationHealthService : IIntegrationHealthService
 {
     private readonly IIntegrationHealthService _inner;

--- a/tests/FlowHub.Web.ComponentTests/DashboardCards/SkillHealthCardTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/DashboardCards/SkillHealthCardTests.cs
@@ -45,4 +45,20 @@ public class SkillHealthCardTests : TestContext
         cut.Markup.Should().Contain("Zitate");
         cut.Markup.Should().Contain("degraded");
     }
+
+    [Fact]
+    public void Manage_ClickInvokesCallback()
+    {
+        var clicks = 0;
+        var cut = RenderComponent<SkillHealthCard>(p => p
+            .Add(c => c.Skills, Array.Empty<SkillHealth>())
+            .Add(c => c.OnManageClick, EventCallback.Factory.Create(this, () => clicks++)));
+
+        var button = cut.FindAll("button")
+            .FirstOrDefault(b => b.TextContent.Contains("Manage", StringComparison.OrdinalIgnoreCase));
+        button.Should().NotBeNull();
+        button!.Click();
+
+        clicks.Should().Be(1);
+    }
 }

--- a/tests/FlowHub.Web.ComponentTests/Pipeline/CaptureEmbeddingConsumerTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/Pipeline/CaptureEmbeddingConsumerTests.cs
@@ -1,0 +1,71 @@
+using FlowHub.Core.Events;
+using FlowHub.Web.Pipeline;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FlowHub.Web.ComponentTests.Pipeline;
+
+public sealed class CaptureEmbeddingConsumerTests
+{
+    [Fact]
+    public async Task Consume_EmbeddingProvided_StoresEmbeddingOnRepository()
+    {
+        var emb = new float[] { 0.1f, 0.2f, 0.3f };
+        var embeddings = Substitute.For<IEmbeddingService>();
+        embeddings.GenerateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<float[]?>(emb));
+        var repo = Substitute.For<ICaptureRepository>();
+        repo.StoreEmbeddingAsync(Arg.Any<Guid>(), Arg.Any<float[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        await using var sp = BuildHarness(embeddings, repo);
+        var harness = sp.GetRequiredService<ITestHarness>();
+        await harness.Start();
+
+        var id = Guid.NewGuid();
+        await sp.GetRequiredService<IBus>().Publish(
+            new CaptureCreated(id, "hello", ChannelKind.Api, DateTimeOffset.UtcNow));
+
+        (await harness.Consumed.Any<CaptureCreated>(x => x.Context.Message.CaptureId == id))
+            .Should().BeTrue();
+
+        await repo.Received(1).StoreEmbeddingAsync(id, Arg.Is<float[]>(v => v.SequenceEqual(emb)), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Consume_NoEmbeddingProvided_LogsSkippedWithoutStoring()
+    {
+        var embeddings = Substitute.For<IEmbeddingService>();
+        embeddings.GenerateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<float[]?>(null));
+        var repo = Substitute.For<ICaptureRepository>();
+
+        await using var sp = BuildHarness(embeddings, repo);
+        var harness = sp.GetRequiredService<ITestHarness>();
+        await harness.Start();
+
+        var id = Guid.NewGuid();
+        await sp.GetRequiredService<IBus>().Publish(
+            new CaptureCreated(id, "hello", ChannelKind.Api, DateTimeOffset.UtcNow));
+
+        (await harness.Consumed.Any<CaptureCreated>(x => x.Context.Message.CaptureId == id))
+            .Should().BeTrue();
+
+        await repo.DidNotReceive().StoreEmbeddingAsync(
+            Arg.Any<Guid>(), Arg.Any<float[]>(), Arg.Any<CancellationToken>());
+    }
+
+    private static ServiceProvider BuildHarness(IEmbeddingService embeddings, ICaptureRepository repo)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>),
+            typeof(Microsoft.Extensions.Logging.Abstractions.NullLogger<>));
+        services.AddSingleton(embeddings);
+        services.AddSingleton(repo);
+        services.AddMassTransitTestHarness(x => x.AddConsumer<CaptureEmbeddingConsumer>());
+        return services.BuildServiceProvider(true);
+    }
+}

--- a/tests/FlowHub.Web.ComponentTests/Pipeline/CaptureNotificationConsumerTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/Pipeline/CaptureNotificationConsumerTests.cs
@@ -1,0 +1,41 @@
+using FlowHub.Core.Events;
+using FlowHub.Web.Notifications;
+using FlowHub.Web.Pipeline;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FlowHub.Web.ComponentTests.Pipeline;
+
+public sealed class CaptureNotificationConsumerTests
+{
+    [Fact]
+    public async Task Consume_ForwardsCaptureCreatedToNotifier()
+    {
+        var notifier = Substitute.For<ICaptureNotifier>();
+        notifier.NotifyCaptureCreatedAsync(Arg.Any<CaptureCreated>(), Arg.Any<CancellationToken>())
+                .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>),
+            typeof(Microsoft.Extensions.Logging.Abstractions.NullLogger<>));
+        services.AddSingleton(notifier);
+        services.AddMassTransitTestHarness(x => x.AddConsumer<CaptureNotificationConsumer>());
+
+        await using var sp = services.BuildServiceProvider(true);
+        var harness = sp.GetRequiredService<ITestHarness>();
+        await harness.Start();
+
+        var msg = new CaptureCreated(Guid.NewGuid(), "hi", ChannelKind.Telegram, DateTimeOffset.UtcNow);
+        await sp.GetRequiredService<IBus>().Publish(msg);
+
+        (await harness.Consumed.Any<CaptureCreated>(x => x.Context.Message.CaptureId == msg.CaptureId))
+            .Should().BeTrue();
+
+        await notifier.Received(1).NotifyCaptureCreatedAsync(
+            Arg.Is<CaptureCreated>(c => c.CaptureId == msg.CaptureId),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Sixth increment of #103. First phase of `FlowHub.Web`.

## Tests added
- **`CaptureEmbeddingConsumer`** (0% → 100%): MassTransit test harness — embedding-present stores on repo; null embedding short-circuits with the skipped log.
- **`CaptureNotificationConsumer`** (0% → 100%): forwards `CaptureCreated` to `ICaptureNotifier`.
- **`SkillHealthCard`** — fills the 0/2 gap on `OnManageClickInternal` via a bUnit click that asserts the `EventCallback` fires.

## Documented exclusions (#103)
`source/FlowHub.Web/Testing/` is E2E-only test scaffolding, active **only** when `FLOWHUB_E2E_FAULTS_ENABLED=true` (see `E2EFaultExtensions.IsEnabled`). Unit-testing it would test the env-var bridge, not behaviour. Marked `[ExcludeFromCodeCoverage]`:
- `E2EFaultExtensions` (77 lines)
- `FaultInjectingSkillRegistry` + `FaultInjectingIntegrationHealthService` (45 lines)

The E2E pipeline already exercises them.

## Result
**`FlowHub.Web`: 68.1% → 75.3%** (1020/1354). All Pipeline consumers and all DashboardCards are now 100%.

## Next phases (separate PRs)
- Blazor pages (`Captures`, `CaptureDetail`, `Dashboard`, `NewCapture`, `MainLayout`) — bUnit-heavy.
- `ProgramRegistration` (58%) — DI wiring branches that can be reached via `WebApplicationFactory`.

Relates to #103.