### PR TITLE
build(release): publish flowhub-migrations image too; surface two-container topology in Arc42 §7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
+      - name: Extract metadata — flowhub-web
+        id: meta-web
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/flowhub-web
@@ -39,14 +39,33 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push Docker image
+      - name: Build and push — flowhub-web
         uses: docker/build-push-action@v5
         with:
           context: .
           file: source/FlowHub.Web/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-web.outputs.tags }}
+          labels: ${{ steps.meta-web.outputs.labels }}
+
+      - name: Extract metadata — flowhub-migrations
+        id: meta-migrations
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/flowhub-migrations
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push — flowhub-migrations
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/migrations/Dockerfile
+          push: true
+          tags: ${{ steps.meta-migrations.outputs.tags }}
+          labels: ${{ steps.meta-migrations.outputs.labels }}
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4

--- a/docs/architektur/FlowHub_Arc42_v2.md
+++ b/docs/architektur/FlowHub_Arc42_v2.md
@@ -651,11 +651,19 @@ Lifecycle zurück auf `Raw`).
 | `prometheus` | `prom/prometheus:latest` | Scrapt `/metrics` (7 d Retention) |
 | `grafana` | `grafana/grafana:latest` | Dashboards (anonymer Viewer, provisioniert) |
 
-Nur `flowhub.web` wird beim Release gebaut und veröffentlicht; `FlowHub.Api` ist
-in den Web-Host gefaltet (ADR 0003, „as built"). Die Demo-Overlay-Compose-Datei
-(`demo/docker-compose.yml`) ergänzt live laufende Ziel-Dienste (Vikunja,
-Wallabag, paperless), einen 15-Minuten-Reset, Traefik-Labels mit Rate-Limit und
-eine Uptime-Kuma-Statusseite.
+**Zwei first-party Container, unabhängig gebaut und veröffentlicht.** Im
+Release-Workflow (`release.yml`, Tag `v*`) werden **beide** Container-Images
+unabhängig voneinander aus dem gleichen Repo gebaut und nach GHCR gepusht — der
+laufende App-Container `ghcr.io/freaxnx01/flowhub-web` und der Init-Container
+`ghcr.io/freaxnx01/flowhub-migrations` (eigene Dockerfile + eigene Versionierung,
+gleiche SemVer-Tags). Damit ist die modular-monolithische Lösung „klar abgegrenzt
+in Module bzw. Sub-Systeme strukturiert … und als Container lauffähig betrieben"
+durch **zwei separat gepullbare, separat startbare, je eigenständig gebaute
+Container** belegbar (vgl. Rubrik *Bewertungskriterien Projektarbeit AISE*,
+Juni 2026, Kriterium 17). `FlowHub.Api` ist gemäss ADR 0003 „as built" in den
+Web-Host gefaltet. Die Demo-Overlay-Compose-Datei (`demo/docker-compose.yml`)
+ergänzt live laufende Ziel-Dienste (Vikunja, Wallabag, paperless), einen
+15-Minuten-Reset, Traefik-Labels mit Rate-Limit und eine Uptime-Kuma-Statusseite.
 
 ### 7.2 CI/CD
 


### PR DESCRIPTION
The submission claims »klar abgegrenzte Module/Sub-Systeme … als Container lauffähig« (Arc42 §7), but `release.yml` only built + pushed `flowhub-web` — so the second first-party container existed only inside the compose file, not on GHCR where an examiner could pull it. This patch closes both halves.

## Changes

- **`release.yml`** — add a second `metadata-action` + `build-push-action` for `flowhub-migrations` (own `docker/migrations/Dockerfile`, own image `ghcr.io/<owner>/flowhub-migrations`, same SemVer + `latest` tags as flowhub-web). Step IDs renamed to `meta-web` / `meta-migrations` so the two images don't share a `steps.meta` output.
- **`docs/architektur/FlowHub_Arc42_v2.md`** — §7.1: drop the now-stale »Nur flowhub.web wird gebaut« note; explain that two first-party containers are independently built + published, citing the rubric criterion (*Bewertungskriterien Projektarbeit AISE, Juni 2026, Krit. 17*) by source rather than verbatim text.

## Why

Submission-relevant fix to a doc/build mismatch found while preparing the examiner walkthrough. Not a feature change — keeps the artefact aligned with what the Arc42 §7 narrative already claims.

## Verification

- After merge + tag, `release.yml` will publish two images per release: `ghcr.io/freaxnx01/flowhub-web:<version>` and `ghcr.io/freaxnx01/flowhub-migrations:<version>`.
- `docker pull ghcr.io/freaxnx01/flowhub-migrations:latest` should succeed on the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)