### PR TITLE
feat(quality): wire Stryker mutation gate (Phase-1 baseline, break=35)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,8 +59,9 @@ jobs:
           test-project: tests/FlowHub.Core.Tests/FlowHub.Core.Tests.csproj
           max-added-cs-lines: "800"
           max-method-lines: "40"
-          run-method-size: "false"   # deferred: Metrics.exe is Linux-incompatible (agent-pipeline#91)
-          run-mutation: "false"      # deferred to Phase-2 (#96)
+          run-method-size: "false"           # deferred: Metrics.exe is Linux-incompatible (agent-pipeline#91)
+          run-mutation: "true"               # enabled in #96 cluster 1 — break is 35 (just below the 37.21% baseline)
+          stryker-config-dir: "source/FlowHub.Core"   # config lives next to FlowHub.Core.csproj
 
   verify-gates:
     name: verify-gates

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,8 @@ coverage*.info
 # Quality gates: scratch dir + generated metrics report (verify-gates / method-size)
 .verify-gates/
 code-metrics.xml
+# Stryker mutation testing report dir (issue #96)
+**/StrykerOutput/
 
 # Visual Studio code coverage results
 *.coverage

--- a/source/FlowHub.Core/stryker-config.json
+++ b/source/FlowHub.Core/stryker-config.json
@@ -1,0 +1,9 @@
+{
+  "stryker-config": {
+    "project": "FlowHub.Core.csproj",
+    "test-projects": ["../../tests/FlowHub.Core.Tests/FlowHub.Core.Tests.csproj"],
+    "thresholds": { "high": 80, "low": 60, "break": 35 },
+    "reporters": ["cleartext", "html"],
+    "mutation-level": "Standard"
+  }
+}


### PR DESCRIPTION
Phase-1 of #96 — the enablement step that was deferred from #94. Measure FlowHub's baseline mutation score and gate CI on it so future regressions in test quality fail the build. The ratchet toward 60 stays open and tracked in #96.

## Measured baseline
`dotnet-stryker` on `FlowHub.Core` against `FlowHub.Core.Tests` (locally):
```
[INF] Time Elapsed 00:00:35.6
[INF] The final mutation score is 37.21 %
STRYKER_EXIT=0
```

## Changes
- **`source/FlowHub.Core/stryker-config.json`**: scope Stryker to `FlowHub.Core` (smallest unit-tested project, keeps the CI run fast). `break = 35` — just below the measured **37.21%** baseline, so adoption is green and a regression flips the gate red.
- **`.github/workflows/quality.yml`**: re-enable `run-mutation: true`, point `stryker-config-dir` at `source/FlowHub.Core` so the config's relative paths resolve.
- **`.gitignore`**: cover `**/StrykerOutput/` so per-run artifacts never leak into commits.

## What stays open
- Issue **#96** (ratchet toward 60). Each cluster: add/strengthen tests in `FlowHub.Core.Tests`, raise `break` toward 60 incrementally. Each PR is one cluster of new tests + a bump to `break`.
- Optionally widen Stryker's scope beyond `FlowHub.Core` later (Persistence, Skills, AI) — those projects already have tests but the CI run would lengthen significantly.