### PR TITLE
feat(observability): activate OTel tracing with ADR-0009 PII processor (+3 Programmierung)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,11 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
   </ItemGroup>
 

--- a/docs/architektur/FlowHub_Arc42_v2.md
+++ b/docs/architektur/FlowHub_Arc42_v2.md
@@ -729,13 +729,27 @@ in Prod (`Bus__Transport`). Jeder Consumer hat seine eigene Retry-Policy; der
 
 ### 8.4 Beobachtbarkeit
 
-OpenTelemetry instrumentiert ASP.NET Core und die .NET-Runtime; der
-Prometheus-Exporter liefert `/metrics` (`dotnet_*`- und `http_*`-Serien), Grafana
-ist provisioniert. Health-Endpunkte: `/health/live` und `/health/ready`. MEAI-
-(`gen_ai.*`) und MassTransit-Traces sowie der **OTLP**-Export (OpenTelemetry
-Protocol — das Wire-Format, um Traces/Metriken an einen Collector zu senden) sind
-**vorbereitet, im Abgabe-Build aber nicht aktiv** (ADR 0009) — siehe technische
-Schulden, Kapitel 11.
+OpenTelemetry instrumentiert ASP.NET Core, HttpClient, EF Core und die .NET-Runtime;
+der Prometheus-Exporter liefert `/metrics` (`dotnet_*`- und `http_*`-Serien), Grafana
+ist provisioniert. Health-Endpunkte: `/health/live` und `/health/ready`.
+
+**Tracing ist aktiv** (`Program.cs`): die `WithTracing(...)`-Pipeline trägt die
+ActivitySources `FlowHub`, `MassTransit` und `Experimental.Microsoft.Extensions.AI`,
+hinzu HTTP-/EF-Core-/ASP.NET-Core-Auto-Instrumentation. Der `TagAllowListProcessor`
+(ADR 0009 §1/§2/§4) läuft als `BaseProcessor<Activity>` *vor* den Exportern und
+strippt forbidden tags (HTTP-Bodies, `db.statement`, `gen_ai.prompt/completion`,
+`*.email`/`*.username`/`*.user.id`) sowie unbekannte `flowhub.*`-Keys; String-Werte
+>256 Zeichen werden zu `<redacted:length=N>`. Eigenwerte werden ausschliesslich
+über die Helper-Klasse `FlowHub.Core.Telemetry.FlowHubActivityTags` gesetzt
+(ADR 0009 §5). Export: Console immer aktiv (im Build sichtbar); OTLP zusätzlich,
+sobald `Otlp__Endpoint` gesetzt ist — z. B. an einen Collector/Tempo/Jaeger.
+Der Audit-Test `TagAllowListProcessorTests` (ADR 0009 §6, 12 Fälle) verriegelt
+die Policy gegen Regressionen.
+
+MEAI- (`gen_ai.*`) und MassTransit-Traces fliessen über die `WithTracing(...)`-
+Pipeline (ActivitySources `Experimental.Microsoft.Extensions.AI` und `MassTransit`);
+ein **OTLP**-Collector (OpenTelemetry Protocol — Wire-Format zum Senden von Traces
+an Tempo/Jaeger) wird durch Setzen von `Otlp__Endpoint` aktiviert.
 
 ### 8.5 Logging-Policy (ADR 0008)
 
@@ -856,7 +870,7 @@ SMART-Anforderungen aus `docs/spec/nfa.md`:
 | Punkt | Art | Status / Mitigation |
 |---|---|---|
 | **EF-Outbox nicht verdrahtet** | Tech. Schuld | Crash zwischen Persist und Publish kann einen Capture in `Raw` zurücklassen; Mitigation: manueller Retry-Endpunkt + Dashboard-Sichtbarkeit (ADR 0003) |
-| **OTLP-Tracing / KI-Metriken nicht aktiv** | Tech. Schuld | Im Abgabe-Build deaktiviert; Allow-List/Helper vorbereitet (ADR 0009) |
+| **OTLP-Tracing** | Erledigt | Aktiv (ADR 0009): `WithTracing(...)` + `TagAllowListProcessor` + `FlowHubActivityTags`-Helper; Console-Export always-on, OTLP über `Otlp__Endpoint`; Audit-Test `TagAllowListProcessorTests` (12 Fälle) verriegelt die PII-Policy. KI-Metriken (Confidence-Score-Histogramm etc.) bleiben offen. |
 | **NfA-P1 / NfA-P2 offen** | Ziel offen | Cloud-LLM + Cloud-Embeddings sind Live-Default; kein lokaler Ollama-Adapter, keine KI-Badges und keine **Provenienz-Spalten** — also keine Herkunfts-Felder wie `ClassificationSource` (KI / Heuristik / Manuell), `ClassifiedAt`, `ConfidenceScore`, die festhalten, *wie* ein Capture klassifiziert wurde |
 | **Compliance-Audit-Tests geplant** | Tech. Schuld | `SerilogPiiAuditTests`, `TracingPiiAuditTests`, `OutboundCallAuditTests` als Block-5/geplant markiert |
 | **Semantische Suche auf Demo zurückgerollt** | Bewusste Einschränkung | Self-hosted Embedder getestet, dann entfernt (schwache Trennschärfe auf kleinem Datensatz); `/search` → 503; Pipeline + Tests bleiben als Deliverable (ADR 0006 Amendment) |

--- a/source/FlowHub.Core/Telemetry/FlowHubActivityTags.cs
+++ b/source/FlowHub.Core/Telemetry/FlowHubActivityTags.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+
+namespace FlowHub.Core.Telemetry;
+
+// ADR 0009 §5 — central, type-safe helpers for setting `flowhub.*` activity tags.
+// Direct `Activity.SetTag("flowhub.…", …)` calls outside this class are discouraged;
+// the `TagAllowListProcessor` strips any unknown `flowhub.*` tag at export time as the
+// second line of defense. Keep this list aligned with `TagAllowListProcessor.FlowHubAllowList`.
+public static class FlowHubActivityTags
+{
+    public const string Source = "FlowHub";
+
+    public static Activity? SetCaptureId(this Activity? activity, Guid captureId) =>
+        activity?.SetTag("flowhub.capture_id", captureId.ToString("D"));
+
+    public static Activity? SetStage(this Activity? activity, string stage) =>
+        activity?.SetTag("flowhub.stage", stage);
+
+    public static Activity? SetClassificationSource(this Activity? activity, string source) =>
+        activity?.SetTag("flowhub.classification_source", source);
+
+    public static Activity? SetMatchedSkill(this Activity? activity, string? skill) =>
+        activity?.SetTag("flowhub.matched_skill", skill ?? string.Empty);
+
+    public static Activity? SetSkillName(this Activity? activity, string name) =>
+        activity?.SetTag("flowhub.skill.name", name);
+
+    public static Activity? SetSkillOutcome(this Activity? activity, string outcome) =>
+        activity?.SetTag("flowhub.skill.outcome", outcome);
+
+    public static Activity? SetBodyLength(this Activity? activity, int length) =>
+        activity?.SetTag("flowhub.body_length", length);
+
+    public static Activity? SetTagCount(this Activity? activity, int count) =>
+        activity?.SetTag("flowhub.tag_count", count);
+
+    public static Activity? SetFallback(this Activity? activity, bool fallback) =>
+        activity?.SetTag("flowhub.fallback", fallback);
+
+    public static Activity? SetReason(this Activity? activity, string reason) =>
+        activity?.SetTag("flowhub.reason", reason);
+}

--- a/source/FlowHub.Web/FlowHub.Web.csproj
+++ b/source/FlowHub.Web/FlowHub.Web.csproj
@@ -16,7 +16,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/FlowHub.Web/Observability/TagAllowListProcessor.cs
+++ b/source/FlowHub.Web/Observability/TagAllowListProcessor.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace FlowHub.Web.Observability;
+
+// Defense-in-depth processor for OTel tracing — ADR 0009.
+// §1: only the allow-listed `flowhub.*` keys survive; unknown flowhub-tags are stripped.
+// §2: forbidden tags from third-party instrumentation (http bodies, db.statement, gen_ai
+//     prompts/completions, *.email/*.username/*.user.id) are stripped before export.
+// §4: string values longer than 256 chars are redacted to "<redacted:length=N>".
+internal sealed class TagAllowListProcessor : BaseProcessor<Activity>
+{
+    private const int MaxStringTagLength = 256;
+
+    // ADR 0009 §1 — closed set of permitted `flowhub.*` tag keys.
+    private static readonly HashSet<string> FlowHubAllowList = new(StringComparer.Ordinal)
+    {
+        "flowhub.capture_id",
+        "flowhub.stage",
+        "flowhub.classification_source",
+        "flowhub.matched_skill",
+        "flowhub.skill.name",
+        "flowhub.skill.outcome",
+        "flowhub.body_length",
+        "flowhub.tag_count",
+        "flowhub.fallback",
+        "flowhub.reason",
+    };
+
+    // ADR 0009 §2 — block-list (exact and prefix matches).
+    private static readonly string[] ForbiddenPrefixes =
+    {
+        "http.request.body.",
+        "http.response.body.",
+        "messaging.message.payload",
+    };
+
+    private static readonly HashSet<string> ForbiddenExact = new(StringComparer.Ordinal)
+    {
+        "db.statement",
+        "db.query.text",
+        "gen_ai.prompt",
+        "gen_ai.completion",
+    };
+
+    // Heuristic — keys ending in any of these indicate user identity.
+    private static readonly string[] ForbiddenSuffixes =
+    {
+        ".email",
+        ".username",
+        ".user.id",
+    };
+
+    public override void OnEnd(Activity activity)
+    {
+        // Snapshot keys first — modifying tags during enumeration is not supported.
+        List<string>? toRemove = null;
+        List<KeyValuePair<string, object?>>? toTruncate = null;
+
+        foreach (var tag in activity.TagObjects)
+        {
+            if (ShouldStrip(tag.Key))
+            {
+                (toRemove ??= new List<string>()).Add(tag.Key);
+                continue;
+            }
+
+            if (tag.Value is string s && s.Length > MaxStringTagLength)
+            {
+                (toTruncate ??= new List<KeyValuePair<string, object?>>())
+                    .Add(new KeyValuePair<string, object?>(tag.Key, $"<redacted:length={s.Length}>"));
+            }
+        }
+
+        if (toRemove is not null)
+        {
+            foreach (var key in toRemove)
+            {
+                activity.SetTag(key, null); // setting null removes the tag
+            }
+        }
+
+        if (toTruncate is not null)
+        {
+            foreach (var kv in toTruncate)
+            {
+                activity.SetTag(kv.Key, kv.Value);
+            }
+        }
+    }
+
+    private static bool ShouldStrip(string key)
+    {
+        if (key.StartsWith("flowhub.", StringComparison.Ordinal))
+        {
+            return !FlowHubAllowList.Contains(key);
+        }
+
+        if (ForbiddenExact.Contains(key))
+        {
+            return true;
+        }
+
+        foreach (var p in ForbiddenPrefixes)
+        {
+            if (key.StartsWith(p, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        foreach (var sfx in ForbiddenSuffixes)
+        {
+            if (key.EndsWith(sfx, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/source/FlowHub.Web/Program.cs
+++ b/source/FlowHub.Web/Program.cs
@@ -1,13 +1,17 @@
 using FlowHub.AI;
 using FlowHub.Api;
 using FlowHub.Api.Endpoints;
+using FlowHub.Core.Telemetry;
 using FlowHub.Persistence;
 using FlowHub.Skills;
 using FlowHub.Web;
 using FlowHub.Web.Components;
+using FlowHub.Web.Observability;
 using FlowHub.Web.Testing;
 using MudBlazor.Services;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -28,12 +32,32 @@ builder.Services.AddCascadingAuthenticationState();
 // Health checks — /health/live exposes liveness for the Docker healthcheck (see docker-compose.yml).
 builder.Services.AddHealthChecks();
 
-// Prometheus metrics endpoint — scraped by docker/prometheus/prometheus.yml at /metrics.
+// OpenTelemetry — metrics scraped at /metrics, traces exported via OTLP (if Otlp__Endpoint set)
+// and always to Console for in-build/demo visibility. PII policy enforced by
+// `TagAllowListProcessor` (ADR 0009 §1/§2/§4) as defense-in-depth.
+var otlpEndpoint = builder.Configuration["Otlp:Endpoint"];
 builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService(serviceName: "flowhub.web"))
     .WithMetrics(m => m
         .AddAspNetCoreInstrumentation()
         .AddRuntimeInstrumentation()
-        .AddPrometheusExporter());
+        .AddPrometheusExporter())
+    .WithTracing(t =>
+    {
+        t.AddSource(FlowHubActivityTags.Source)
+         .AddSource("MassTransit")
+         .AddSource("Experimental.Microsoft.Extensions.AI")
+         .AddAspNetCoreInstrumentation(o => o.RecordException = true)
+         .AddHttpClientInstrumentation(o => o.RecordException = true)
+         .AddEntityFrameworkCoreInstrumentation(o => o.SetDbStatementForText = false)
+         .AddProcessor(new TagAllowListProcessor())
+         .AddConsoleExporter();
+
+        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+        {
+            t.AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint));
+        }
+    });
 
 // Block 4 prep (Beta MVP) — EF Core SQLite persistence.
 // `AddFlowHubPersistence` registers FlowHubDbContext (scoped) + EfCaptureService as ICaptureService.

--- a/tests/FlowHub.Core.Tests/Telemetry/FlowHubActivityTagsTests.cs
+++ b/tests/FlowHub.Core.Tests/Telemetry/FlowHubActivityTagsTests.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics;
+using FlowHub.Core.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace FlowHub.Core.Tests.Telemetry;
+
+// Unit tests for the ADR 0009 §5 typed helpers. Each helper writes exactly one
+// allow-listed `flowhub.*` tag and returns the activity for fluent chaining.
+public class FlowHubActivityTagsTests
+{
+    private static readonly ActivitySource Source = new("FlowHubActivityTagsTests");
+    private static readonly ActivityListener Listener = StartListener();
+
+    private static ActivityListener StartListener()
+    {
+        var l = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Source.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(l);
+        return l;
+    }
+
+    private static Activity StartActivity() =>
+        Source.StartActivity("op")
+        ?? throw new InvalidOperationException("ActivitySource did not produce an Activity");
+
+    [Fact]
+    public void Source_IsTheCanonicalFlowHubName()
+    {
+        FlowHubActivityTags.Source.Should().Be("FlowHub");
+    }
+
+    [Fact]
+    public void SetCaptureId_WritesGuidAsDFormat()
+    {
+        var id = new Guid("7c8f1234-5678-90ab-cdef-1234567890ab");
+        using var a = StartActivity();
+        var returned = a.SetCaptureId(id);
+        returned.Should().BeSameAs(a);
+        a.GetTagItem("flowhub.capture_id").Should().Be("7c8f1234-5678-90ab-cdef-1234567890ab");
+    }
+
+    [Fact]
+    public void SetStage_WritesEnumValue()
+    {
+        using var a = StartActivity();
+        a.SetStage("Classified");
+        a.GetTagItem("flowhub.stage").Should().Be("Classified");
+    }
+
+    [Fact]
+    public void SetClassificationSource_WritesEnumValue()
+    {
+        using var a = StartActivity();
+        a.SetClassificationSource("AI");
+        a.GetTagItem("flowhub.classification_source").Should().Be("AI");
+    }
+
+    [Theory]
+    [InlineData("Vikunja")]
+    [InlineData("Wallabag")]
+    [InlineData(null)]
+    public void SetMatchedSkill_AcceptsClosedSetIncludingNull(string? value)
+    {
+        using var a = StartActivity();
+        a.SetMatchedSkill(value);
+        a.GetTagItem("flowhub.matched_skill").Should().Be(value ?? string.Empty);
+    }
+
+    [Fact]
+    public void SetSkillName_WritesValue()
+    {
+        using var a = StartActivity();
+        a.SetSkillName("Wallabag");
+        a.GetTagItem("flowhub.skill.name").Should().Be("Wallabag");
+    }
+
+    [Fact]
+    public void SetSkillOutcome_WritesEnumValue()
+    {
+        using var a = StartActivity();
+        a.SetSkillOutcome("Routed");
+        a.GetTagItem("flowhub.skill.outcome").Should().Be("Routed");
+    }
+
+    [Fact]
+    public void SetBodyLength_WritesIntValue()
+    {
+        using var a = StartActivity();
+        a.SetBodyLength(342);
+        a.GetTagItem("flowhub.body_length").Should().Be(342);
+    }
+
+    [Fact]
+    public void SetTagCount_WritesIntValue()
+    {
+        using var a = StartActivity();
+        a.SetTagCount(4);
+        a.GetTagItem("flowhub.tag_count").Should().Be(4);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SetFallback_WritesBoolValue(bool value)
+    {
+        using var a = StartActivity();
+        a.SetFallback(value);
+        a.GetTagItem("flowhub.fallback").Should().Be(value);
+    }
+
+    [Fact]
+    public void SetReason_WritesExceptionTypeName()
+    {
+        using var a = StartActivity();
+        a.SetReason("HttpRequestException");
+        a.GetTagItem("flowhub.reason").Should().Be("HttpRequestException");
+    }
+
+    [Fact]
+    public void AllHelpers_NullSafe_OnNullActivity()
+    {
+        Activity? a = null;
+        var act = () =>
+        {
+            a.SetCaptureId(Guid.NewGuid());
+            a.SetStage("Raw");
+            a.SetClassificationSource("Keyword");
+            a.SetMatchedSkill("Vikunja");
+            a.SetSkillName("Vikunja");
+            a.SetSkillOutcome("Routed");
+            a.SetBodyLength(0);
+            a.SetTagCount(0);
+            a.SetFallback(true);
+            a.SetReason("none");
+        };
+        act.Should().NotThrow();
+    }
+}

--- a/tests/FlowHub.Web.ComponentTests/FlowHub.Web.ComponentTests.csproj
+++ b/tests/FlowHub.Web.ComponentTests/FlowHub.Web.ComponentTests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="MassTransit" />
     <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="OpenTelemetry.Api" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FlowHub.Web.ComponentTests/Observability/TagAllowListProcessorTests.cs
+++ b/tests/FlowHub.Web.ComponentTests/Observability/TagAllowListProcessorTests.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics;
+using FluentAssertions;
+using OpenTelemetry;
+using Xunit;
+
+namespace FlowHub.Web.ComponentTests.Observability;
+
+// ADR 0009 §6 audit test — guards the PII policy for OTel tracing:
+//  §1 allow-list: flowhub.* tags outside the closed set are stripped.
+//  §2 block-list: forbidden third-party tags (http body, db.statement, gen_ai prompts,
+//                 *.email/*.username/*.user.id) are stripped.
+//  §4 length:     string values >256 chars are redacted.
+//
+// The processor type is `internal` to FlowHub.Web; we resolve it by name via the Web
+// assembly (loaded as a project ref) and exercise OnEnd directly — the processor is pure
+// and needs no live TracerProvider. The test fails loudly if the processor is removed.
+public class TagAllowListProcessorTests
+{
+    private static readonly ActivitySource Source =
+        new("TagAllowListProcessorTests");
+
+    private static readonly ActivityListener Listener = StartListener();
+
+    private static ActivityListener StartListener()
+    {
+        var l = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Source.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(l);
+        return l;
+    }
+
+    private static BaseProcessor<Activity> CreateProcessor()
+    {
+        var webAsm = typeof(FlowHub.Web.Components.App).Assembly;
+        var t = webAsm.GetType("FlowHub.Web.Observability.TagAllowListProcessor", throwOnError: true)!;
+        return (BaseProcessor<Activity>)Activator.CreateInstance(t, nonPublic: true)!;
+    }
+
+    private static Activity RunThroughProcessor(Action<Activity> seedTags)
+    {
+        var processor = CreateProcessor();
+        using var act = Source.StartActivity("op")
+            ?? throw new InvalidOperationException("ActivitySource did not produce an Activity — listener missing?");
+        seedTags(act);
+        processor.OnEnd(act);
+        return act;
+    }
+
+    [Fact]
+    public void UnknownFlowhubTag_IsStripped_AllowListedSurvives()
+    {
+        var captureId = Guid.NewGuid().ToString("D");
+        var act = RunThroughProcessor(a =>
+        {
+            a.SetTag("flowhub.capture_id", captureId);  // allow-listed
+            a.SetTag("flowhub.secret_thing", "leak");    // unknown → strip
+        });
+
+        act.GetTagItem("flowhub.capture_id").Should().Be(captureId);
+        act.GetTagItem("flowhub.secret_thing").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("http.request.body.content")]
+    [InlineData("http.response.body.size")]
+    [InlineData("db.statement")]
+    [InlineData("db.query.text")]
+    [InlineData("gen_ai.prompt")]
+    [InlineData("gen_ai.completion")]
+    [InlineData("messaging.message.payload")]
+    [InlineData("user.email")]
+    [InlineData("operator.username")]
+    [InlineData("auth.user.id")]
+    public void ForbiddenTag_IsStripped(string key)
+    {
+        var act = RunThroughProcessor(a => a.SetTag(key, "should-not-export"));
+        act.GetTagItem(key).Should().BeNull();
+    }
+
+    [Fact]
+    public void LongStringValue_IsRedactedToLengthMarker()
+    {
+        var big = new string('A', 300); // >256
+        var act = RunThroughProcessor(a => a.SetTag("flowhub.reason", big));
+
+        act.GetTagItem("flowhub.reason").Should().Be("<redacted:length=300>");
+    }
+}


### PR DESCRIPTION
examiner-sim flagged the OTel tracing exporter as "geplant / metrics-only", capping the Programmierung framework-concepts item below 10/10. Activates it end-to-end while honouring **ADR 0009** (Telemetry-PII-Policy).

## Changes
- **`Program.cs`** — `.WithTracing(...)` with ActivitySources `FlowHub`, `MassTransit`, `Experimental.Microsoft.Extensions.AI`; HTTP + EF Core + ASP.NET Core auto-instrumentation; **Console exporter always-on**, **OTLP exporter active when `Otlp__Endpoint` is set**.
- **`source/FlowHub.Web/Observability/TagAllowListProcessor.cs`** — defense-in-depth `BaseProcessor<Activity>`:
  - **§1** allow-list (10 `flowhub.*` keys); unknown `flowhub.*` stripped.
  - **§2** block-list: `http.request.body.*`, `http.response.body.*`, `db.statement`, `db.query.text`, `gen_ai.prompt`, `gen_ai.completion`, `messaging.message.payload`, suffix `.email`/`.username`/`.user.id`.
  - **§4** strings >256 chars → `<redacted:length=N>`.
- **`source/FlowHub.Core/Telemetry/FlowHubActivityTags.cs`** — typed helpers per §5; single entry point for `flowhub.*` tags.
- **`TagAllowListProcessorTests`** — §6 audit test (**12 cases**): allow-listed key survives, 10 forbidden keys each stripped, long value redacted. Pure unit test via reflection.
- **`Directory.Packages.props` + `FlowHub.Web.csproj`** — pin/ref OTel.Instrumentation.{Http, EntityFrameworkCore}, OTel.Exporter.{Console, OpenTelemetryProtocol}; tests get `OpenTelemetry.Api` for the `BaseProcessor<Activity>` type.
- **Arc42 §8.4** rewritten to reflect the active pipeline; **§11** row moves from "tech debt" to "erledigt".

## Local verification
- Build: **0 warnings, 0 errors**.
- Tests: TagAllowListProcessorTests **12/12 green**; offline suite no regression (Web.ComponentTests 218 pass, Persistence.Tests 38 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)