### PR TITLE
docs: link NfA + AC catalogues in Übersicht §3.3; document Otlp__Endpoint

### DIFF
--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -85,7 +85,9 @@ Die ausführliche Projektbeschreibung mit Stakeholdern, Funktionsumfang, Archite
 ### 3.3 Spezifikation & Design
 
 - [System Context](https://github.com/freaxnx01/FlowHub-CAS-AISE/blob/main/docs/spec/system-context.md)
-- [Use Cases](https://github.com/freaxnx01/FlowHub-CAS-AISE/blob/main/docs/spec/use-cases.md)
+- [Use Cases (UC-01…UC-18)](https://github.com/freaxnx01/FlowHub-CAS-AISE/blob/main/docs/spec/use-cases.md)
+- [Non-functional Attributes (SMART NfA)](https://github.com/freaxnx01/FlowHub-CAS-AISE/blob/main/docs/spec/nfa.md)
+- [Acceptance Criteria (50 ACs, Verified-by + NfA-Linkage)](https://github.com/freaxnx01/FlowHub-CAS-AISE/blob/main/docs/spec/acceptance-criteria.md)
 - [Testing Strategy](https://github.com/freaxnx01/FlowHub-CAS-AISE/blob/main/docs/spec/testing-strategy.md)
 - UI-Design-Output (Wireframes & Flows pro Feature):
   - [Dashboard](https://github.com/freaxnx01/FlowHub-CAS-AISE/tree/main/docs/design/dashboard)

--- a/source/FlowHub.Web/appsettings.json
+++ b/source/FlowHub.Web/appsettings.json
@@ -6,6 +6,10 @@
     }
   },
   "AllowedHosts": "*",
+  "Otlp": {
+    "_comment": "OTLP tracing endpoint (e.g. http://otel-collector:4317 for gRPC). Leave empty/unset in dev: the Console exporter still runs. Override via env var Otlp__Endpoint in deployment to ship traces to Tempo / Jaeger / an OpenTelemetry Collector. Span tags are sanitised by TagAllowListProcessor per ADR 0009.",
+    "Endpoint": ""
+  },
   "FlowHub": {
     "Uploads": {
       "MaxBytes": 2097152,


### PR DESCRIPTION
Two small polish items from the post-merge sweep:

- **`SUBMISSION.md` §3.3** — add direct links to `docs/spec/nfa.md` and `docs/spec/acceptance-criteria.md` (Arc42 §1.2/§10/§8.9 reference them, but the entry doc didn't link them). Also label use-cases as **UC-01…UC-18**.
- **`source/FlowHub.Web/appsettings.json`** — new `Otlp` section with a `_comment` documenting how to point tracing at a Tempo/Jaeger/OTel collector via `Otlp__Endpoint`; matches the existing Skills.\_comment pattern. The Console exporter stays active by default.

Pure docs. Only `00_Uebersicht.pdf` regenerates from the SUBMISSION.md change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)