### PR TITLE
feat(quality): widen Stryker to FlowHub.Persistence (scheduled mutation gate)

### DIFF
--- a/.github/workflows/mutation-extended.yml
+++ b/.github/workflows/mutation-extended.yml
@@ -1,0 +1,62 @@
+name: mutation-extended
+
+# Extended Stryker mutation runs for the larger projects that the per-PR
+# `quality` gate doesn't cover (FlowHub.Core is gated there in ~35s; running
+# Stryker on Persistence / Skills inline would push the PR gate past 30 min).
+# This runs on a weekly schedule and on demand, with one parallel job per
+# scoped project. Failures show up in the workflow run but do NOT block PRs.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"   # Mondays 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    name: mutation (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - FlowHub.Persistence
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5.3.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install Stryker.NET
+        run: dotnet tool install -g dotnet-stryker
+
+      - name: Restore + build (Stryker needs the test project built)
+        run: dotnet build FlowHub.slnx -c Release --nologo
+
+      - name: Run Stryker on ${{ matrix.project }}
+        env:
+          STRYKER_PROJECT: ${{ matrix.project }}
+        run: |
+          set -euo pipefail
+          cd "source/${STRYKER_PROJECT}"
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          dotnet-stryker
+
+      - name: Upload Stryker report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: stryker-report-${{ matrix.project }}
+          path: source/${{ matrix.project }}/StrykerOutput/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/source/FlowHub.Persistence/stryker-config.json
+++ b/source/FlowHub.Persistence/stryker-config.json
@@ -1,0 +1,12 @@
+{
+  "stryker-config": {
+    "project": "FlowHub.Persistence.csproj",
+    "test-projects": ["../../tests/FlowHub.Persistence.Tests/FlowHub.Persistence.Tests.csproj"],
+    "thresholds": { "high": 80, "low": 60, "break": 0 },
+    "reporters": ["cleartext", "html"],
+    "mutation-level": "Standard",
+    "mutate": [
+      "!**/Migrations/*.cs"
+    ]
+  }
+}


### PR DESCRIPTION
Part of **#96** (widen Stryker beyond FlowHub.Core).

Per-PR Stryker on FlowHub.Persistence is unworkable: a local measurement with Migrations excluded identified **227 mutants** and the run was still in progress after 14 min — that would push the PR gate well past 30 min. So this adds a **separate weekly workflow** that doesn't block PRs.

## Changes
- **`.github/workflows/mutation-extended.yml`** — cron Mondays 04:00 UTC + `workflow_dispatch`. Matrix-driven, one parallel job per scoped project; starts with FlowHub.Persistence and is wired to accept more entries (Skills next). Each job uploads StrykerOutput as an artifact for 30 days.
- **`source/FlowHub.Persistence/stryker-config.json`** — scope Persistence with scaffold-generated Migrations excluded via `mutate: ['!**/Migrations/*.cs']` (analogous to the existing CA1506 Migrations carve-out). `break = 0` for now — the first scheduled run produces the real baseline, then a follow-up PR raises break (per the #96 baseline-then-ratchet pattern from #124 → #125).

## What stays the same
- Per-PR `quality` gate is unchanged: Stryker still runs only on FlowHub.Core at break=70 (current score 86.05%).
- No required-check status changes; the scheduled workflow runs are informational only until break is tuned.

## Next steps
- After merge: trigger the workflow manually once (`gh workflow run mutation-extended.yml`) to land a real Persistence baseline number, then file a small ratchet PR setting `break` just below it.
- Extend the matrix to FlowHub.Skills (separate PR; same pattern).