### PR TITLE
feat(quality): widen Stryker to FlowHub.Skills (extend mutation-extended matrix)

### DIFF
--- a/.github/workflows/mutation-extended.yml
+++ b/.github/workflows/mutation-extended.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         project:
           - FlowHub.Persistence
+          - FlowHub.Skills
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/source/FlowHub.Skills/stryker-config.json
+++ b/source/FlowHub.Skills/stryker-config.json
@@ -1,0 +1,9 @@
+{
+  "stryker-config": {
+    "project": "FlowHub.Skills.csproj",
+    "test-projects": ["../../tests/FlowHub.Skills.Tests/FlowHub.Skills.Tests.csproj"],
+    "thresholds": { "high": 80, "low": 60, "break": 0 },
+    "reporters": ["cleartext", "html"],
+    "mutation-level": "Standard"
+  }
+}


### PR DESCRIPTION
Part of **#96**. Adds **FlowHub.Skills** to the scheduled `mutation-extended` matrix added by #131.

## Changes
- **`source/FlowHub.Skills/stryker-config.json`** — scope Stryker against FlowHub.Skills (11 source files: 4 skill integrations, options classes, DI extensions). Tests: `FlowHub.Skills.Tests` (54 tests pass locally). `break = 0` — same baseline-then-ratchet pattern as Persistence (#131) and Core (#124 → #125).
- **`mutation-extended.yml` matrix** — append `FlowHub.Skills`; cron / dispatch / artifact upload are shared.

## Per-PR gate unchanged
Stryker still runs only on FlowHub.Core at break=70 (current score 86.05%).

## Next steps
- After merge: trigger `mutation-extended` manually to land the Skills baseline number, then a small ratchet PR sets `break` just below it.
- AI project has no offline unit tests (`FlowHub.AI.IntegrationTests` are live API tests) — widening Stryker there isn't directly applicable without adding offline tests first.