### PR TITLE
fix(quality): tune Skills Stryker break to 55 (CI baseline 61.97%); add json reporter

### DIFF
--- a/source/FlowHub.Persistence/stryker-config.json
+++ b/source/FlowHub.Persistence/stryker-config.json
@@ -3,7 +3,7 @@
     "project": "FlowHub.Persistence.csproj",
     "test-projects": ["../../tests/FlowHub.Persistence.Tests/FlowHub.Persistence.Tests.csproj"],
     "thresholds": { "high": 80, "low": 60, "break": 0 },
-    "reporters": ["cleartext", "html"],
+    "reporters": ["cleartext", "html", "json"],
     "mutation-level": "Standard",
     "mutate": [
       "!**/Migrations/*.cs"

--- a/source/FlowHub.Skills/stryker-config.json
+++ b/source/FlowHub.Skills/stryker-config.json
@@ -2,8 +2,8 @@
   "stryker-config": {
     "project": "FlowHub.Skills.csproj",
     "test-projects": ["../../tests/FlowHub.Skills.Tests/FlowHub.Skills.Tests.csproj"],
-    "thresholds": { "high": 80, "low": 60, "break": 0 },
-    "reporters": ["cleartext", "html"],
+    "thresholds": { "high": 80, "low": 60, "break": 55 },
+    "reporters": ["cleartext", "html", "json"],
     "mutation-level": "Standard"
   }
 }


### PR DESCRIPTION
Part of **#96**. First scheduled `mutation-extended` run (workflow_dispatch [27972167552](https://github.com/freaxnx01/FlowHub-CAS-AISE/actions/runs/27972167552)) measured **FlowHub.Skills at 61.97 %** — already above the canonical 60 (the existing 54 unit tests are doing real work).

## Changes
- **`source/FlowHub.Skills/stryker-config.json`** — `break: 0 → 55` (just below the measured 61.97 %, so adoption is green and a regression flips red).
- **`source/FlowHub.Skills/stryker-config.json`** + **`source/FlowHub.Persistence/stryker-config.json`** — add `json` reporter so future scheduled-run artifacts are easy to parse (the HTML report bundles its data into JS).

## Persistence
Run 27972167552 is still in progress for Persistence (227 mutants). Once it completes, a separate small PR raises its `break` to (baseline − ~5) the same way.

## Verification
Local Stryker run with new break:
```
[INF] Time Elapsed 00:01:48.4
[INF] The final mutation score is 61.97 %
exit=0
```