### PR TITLE
fix(quality): tune Persistence Stryker break to 45 (CI baseline 50.15%)

### DIFF
--- a/source/FlowHub.Persistence/stryker-config.json
+++ b/source/FlowHub.Persistence/stryker-config.json
@@ -2,7 +2,7 @@
   "stryker-config": {
     "project": "FlowHub.Persistence.csproj",
     "test-projects": ["../../tests/FlowHub.Persistence.Tests/FlowHub.Persistence.Tests.csproj"],
-    "thresholds": { "high": 80, "low": 60, "break": 0 },
+    "thresholds": { "high": 80, "low": 60, "break": 45 },
     "reporters": ["cleartext", "html", "json"],
     "mutation-level": "Standard",
     "mutate": [


### PR DESCRIPTION
Part of **#96**. First scheduled `mutation-extended` run ([27972167552](https://github.com/freaxnx01/FlowHub-CAS-AISE/actions/runs/27972167552)) measured **FlowHub.Persistence at 50.15 %** over 7 minutes on a fresh CI runner (Migrations excluded; 227 mutants tested).

## Change
`source/FlowHub.Persistence/stryker-config.json`: `break: 0 → 45` (just below the measured 50.15 % so adoption is green and a regression flips red). Same pattern as Skills (#133) and Core (#124 → #125).

## Honest note
50% is **below the canonical 60**. The ratchet toward 60+ is incremental test-writing work on the EF repositories (each cluster of new tests + a small break bump); that stays open in #96. This PR just locks in what we have so it doesn't regress.

## Stryker run snippet
```
[INF] 227   total mutants will be tested
[INF] Time Elapsed 00:07:06.2
[INF] The final mutation score is 50.15 %
```