### PR TITLE
test(coverage): Persistence — cover EfChannel/EfSkillRun/EfTag repos

### DIFF
--- a/tests/FlowHub.Persistence.Tests/Repositories/EfChannelRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfChannelRepositoryTests.cs
@@ -1,0 +1,109 @@
+using FlowHub.Core.Captures;
+using FlowHub.Core.Channels;
+using FlowHub.Core.Health;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfChannelRepositoryTests(PostgresFixture fixture)
+{
+    private static Channel NewChannel(
+        string name,
+        ChannelKind kind = ChannelKind.Web,
+        bool enabled = true,
+        HealthStatus status = HealthStatus.Healthy,
+        DateTimeOffset? lastActive = null) =>
+        new(name, kind, enabled, status, lastActive);
+
+    [Fact]
+    public async Task GetAllAsync_EmptyDb_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfChannelRepository(db);
+
+        var result = await repo.GetAllAsync();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithSeededChannels_ReturnsAllAsDomain()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfChannelRepository(db);
+        await repo.UpsertAsync(NewChannel("Web", ChannelKind.Web));
+        await repo.UpsertAsync(NewChannel("Telegram", ChannelKind.Telegram, enabled: false, status: HealthStatus.Down));
+
+        var result = await repo.GetAllAsync();
+
+        result.Should().HaveCount(2);
+        result.Should().ContainSingle(c =>
+            c.Name == "Web" && c.Kind == ChannelKind.Web && c.IsEnabled && c.Status == HealthStatus.Healthy);
+        result.Should().ContainSingle(c =>
+            c.Name == "Telegram" && c.Kind == ChannelKind.Telegram && !c.IsEnabled && c.Status == HealthStatus.Down);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_KnownName_ReturnsChannel()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfChannelRepository(db);
+        var lastActive = DateTimeOffset.UtcNow.AddMinutes(-3);
+        await repo.UpsertAsync(NewChannel("Api", ChannelKind.Api, lastActive: lastActive));
+
+        var result = await repo.GetByNameAsync("Api");
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Api");
+        result.Kind.Should().Be(ChannelKind.Api);
+        result.LastActiveAt.Should().BeCloseTo(lastActive, TimeSpan.FromMilliseconds(1));
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_UnknownName_ReturnsNull()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfChannelRepository(db);
+
+        var result = await repo.GetByNameAsync("does-not-exist");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_NewChannel_InsertsRow()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfChannelRepository(db);
+
+        await repo.UpsertAsync(NewChannel("Telegram", ChannelKind.Telegram, status: HealthStatus.Degraded));
+
+        var stored = await repo.GetByNameAsync("Telegram");
+        stored.Should().NotBeNull();
+        stored!.Kind.Should().Be(ChannelKind.Telegram);
+        stored.Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_ExistingChannel_UpdatesMutableFields()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfChannelRepository(db);
+        await repo.UpsertAsync(NewChannel("Web", ChannelKind.Web, enabled: true, status: HealthStatus.Healthy));
+
+        var newActiveAt = DateTimeOffset.UtcNow;
+        await repo.UpsertAsync(new Channel("Web", ChannelKind.Api, IsEnabled: false, HealthStatus.Down, newActiveAt));
+
+        var stored = await repo.GetByNameAsync("Web");
+        stored.Should().NotBeNull();
+        stored!.Kind.Should().Be(ChannelKind.Api);
+        stored.IsEnabled.Should().BeFalse();
+        stored.Status.Should().Be(HealthStatus.Down);
+        stored.LastActiveAt.Should().BeCloseTo(newActiveAt, TimeSpan.FromMilliseconds(1));
+
+        // Should be an update, not a duplicate insert.
+        (await repo.GetAllAsync()).Should().ContainSingle();
+    }
+}

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRunRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRunRepositoryTests.cs
@@ -1,0 +1,145 @@
+using FlowHub.Core.Captures;
+using FlowHub.Core.Health;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfSkillRunRepositoryTests(PostgresFixture fixture)
+{
+    // SkillRunEntity has FKs to Skill (by SkillName, Restrict) and Capture (Cascade),
+    // so each test seeds the parent rows via the existing EF repositories.
+    private static async Task<(Guid captureId, string skillName)> SeedParents(
+        FlowHubDbContext db, string skillName = "Movies", string content = "test capture")
+    {
+        var skillRepo = new EfSkillRepository(db);
+        await skillRepo.UpsertAsync(new SkillHealth(skillName, HealthStatus.Healthy, 0));
+
+        var captureRepo = new EfCaptureRepository(db);
+        var capture = new Capture(
+            Guid.NewGuid(), ChannelKind.Web, content, DateTimeOffset.UtcNow, LifecycleStage.Raw, null);
+        await captureRepo.AddAsync(capture);
+
+        return (capture.Id, skillName);
+    }
+
+    private static SkillRun NewRun(
+        Guid captureId,
+        string skillName,
+        DateTimeOffset startedAt,
+        bool success = true,
+        string? failureReason = null) =>
+        new(
+            Guid.NewGuid(),
+            skillName,
+            captureId,
+            startedAt,
+            CompletedAt: startedAt.AddMilliseconds(150),
+            Success: success,
+            FailureReason: failureReason);
+
+    [Fact]
+    public async Task AddAsync_PersistsAllFields_AndReturnsInputUnchanged()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfSkillRunRepository(db);
+        var (captureId, skillName) = await SeedParents(db);
+        var run = NewRun(captureId, skillName, DateTimeOffset.UtcNow);
+
+        var returned = await repo.AddAsync(run);
+
+        returned.Should().BeSameAs(run);
+
+        var read = (await repo.GetByCaptureIdAsync(captureId)).Single();
+        read.Id.Should().Be(run.Id);
+        read.SkillName.Should().Be(skillName);
+        read.CaptureId.Should().Be(captureId);
+        read.StartedAt.Should().BeCloseTo(run.StartedAt, TimeSpan.FromMilliseconds(1));
+        read.CompletedAt.Should().BeCloseTo(run.CompletedAt!.Value, TimeSpan.FromMilliseconds(1));
+        read.Success.Should().BeTrue();
+        read.FailureReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddAsync_FailureRun_PersistsFailureReason_AndNullCompletedAt()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfSkillRunRepository(db);
+        var (captureId, skillName) = await SeedParents(db);
+
+        var run = new SkillRun(
+            Guid.NewGuid(), skillName, captureId,
+            StartedAt: DateTimeOffset.UtcNow,
+            CompletedAt: null,
+            Success: false,
+            FailureReason: "Wallabag 503");
+        await repo.AddAsync(run);
+
+        var read = (await repo.GetByCaptureIdAsync(captureId)).Single();
+        read.Success.Should().BeFalse();
+        read.CompletedAt.Should().BeNull();
+        read.FailureReason.Should().Be("Wallabag 503");
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_ReturnsOnlyRowsForThatCapture_OrderedByStartedAtDesc()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfSkillRunRepository(db);
+        var (capA, skill) = await SeedParents(db, skillName: "Movies", content: "A");
+        var (capB, _) = await SeedParents(db, skillName: "Movies", content: "B");
+
+        var now = DateTimeOffset.UtcNow;
+        await repo.AddAsync(NewRun(capA, skill, now.AddMinutes(-10)));
+        await repo.AddAsync(NewRun(capA, skill, now.AddMinutes(-1)));
+        await repo.AddAsync(NewRun(capB, skill, now)); // belongs to capture B, must be excluded
+
+        var result = await repo.GetByCaptureIdAsync(capA);
+
+        result.Should().HaveCount(2);
+        result[0].StartedAt.Should().BeAfter(result[1].StartedAt);
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_NoRuns_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfSkillRunRepository(db);
+
+        var result = await repo.GetByCaptureIdAsync(Guid.NewGuid());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetBySkillNameAsync_ReturnsOnlyRowsForThatSkill_OrderedByStartedAtDesc()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfSkillRunRepository(db);
+        var (capA, _) = await SeedParents(db, skillName: "Movies", content: "A");
+        var (_, _) = await SeedParents(db, skillName: "Books", content: "B");
+
+        var now = DateTimeOffset.UtcNow;
+        await repo.AddAsync(NewRun(capA, "Movies", now.AddMinutes(-5)));
+        await repo.AddAsync(NewRun(capA, "Movies", now));
+        await repo.AddAsync(NewRun(capA, "Books",  now.AddMinutes(-2)));
+
+        var result = await repo.GetBySkillNameAsync("Movies");
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(r => r.SkillName == "Movies");
+        result[0].StartedAt.Should().BeAfter(result[1].StartedAt);
+    }
+
+    [Fact]
+    public async Task GetBySkillNameAsync_UnknownSkill_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfSkillRunRepository(db);
+
+        var result = await repo.GetBySkillNameAsync("Nope");
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfTagRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfTagRepositoryTests.cs
@@ -1,0 +1,90 @@
+using FlowHub.Core.Captures;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfTagRepositoryTests(PostgresFixture fixture)
+{
+    // TagEntity has a cascade FK to Capture(CaptureId), so every Tag needs a
+    // parent Capture row before insert.
+    private static async Task<Guid> SeedCapture(FlowHubDbContext db, string content = "tagged capture")
+    {
+        var captureRepo = new EfCaptureRepository(db);
+        var capture = new Capture(
+            Guid.NewGuid(), ChannelKind.Web, content, DateTimeOffset.UtcNow, LifecycleStage.Raw, null);
+        await captureRepo.AddAsync(capture);
+        return capture.Id;
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_NoTags_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfTagRepository(db);
+
+        var result = await repo.GetByCaptureIdAsync(Guid.NewGuid());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsTag_AndGetByCaptureIdReturnsIt()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfTagRepository(db);
+        var captureId = await SeedCapture(db);
+
+        await repo.AddAsync(captureId, "stoic");
+
+        var result = await repo.GetByCaptureIdAsync(captureId);
+        result.Should().ContainSingle().Which.Should().Be("stoic");
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_ScopesToOwnerCapture_OnlyOwnerTagsReturned()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfTagRepository(db);
+        var capA = await SeedCapture(db, "A");
+        var capB = await SeedCapture(db, "B");
+        await repo.AddAsync(capA, "alpha");
+        await repo.AddAsync(capA, "beta");
+        await repo.AddAsync(capB, "gamma");
+
+        var result = await repo.GetByCaptureIdAsync(capA);
+
+        result.Should().BeEquivalentTo(["alpha", "beta"]);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_KnownTag_DeletesIt()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfTagRepository(db);
+        var captureId = await SeedCapture(db);
+        await repo.AddAsync(captureId, "alpha");
+        await repo.AddAsync(captureId, "beta");
+
+        await repo.RemoveAsync(captureId, "alpha");
+
+        var result = await repo.GetByCaptureIdAsync(captureId);
+        result.Should().BeEquivalentTo(["beta"]);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_UnknownTag_NoOps_DoesNotThrow()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var repo = new EfTagRepository(db);
+        var captureId = await SeedCapture(db);
+        await repo.AddAsync(captureId, "alpha");
+
+        var act = () => repo.RemoveAsync(captureId, "ghost");
+
+        await act.Should().NotThrowAsync();
+        var result = await repo.GetByCaptureIdAsync(captureId);
+        result.Should().BeEquivalentTo(["alpha"]);
+    }
+}


### PR DESCRIPTION
## Summary

First slice of [#126](../../issues/126) §B — three previously-untested EF repositories taken from 0 % to 100 % on the Testcontainers Postgres baseline.

| File | Was | Now | Tests |
|---|---:|---:|---:|
| `Repositories/EfChannelRepository.cs` | 0 % | 100 % (15/15) | 6 |
| `Repositories/EfSkillRunRepository.cs` | 0 % | 100 % (9/9) | 6 |
| `Repositories/EfTagRepository.cs` | 0 % | 100 % (1/1) | 5 |
| **`FlowHub.Persistence` assembly** | **76.4 %** | **84.9 %** | — |

## What the tests cover

- **EfChannelRepository:** `GetAll` empty/populated; `GetByName` hit/miss; `Upsert` insert path; `Upsert` update path (kind/isEnabled/status/lastActiveAt, asserts no duplicate insert).
- **EfSkillRunRepository:** `AddAsync` persists all fields + nullable `CompletedAt` + `FailureReason`; `GetByCaptureId` and `GetBySkillName` scoping + `StartedAt`-desc ordering; empty-result cases.
- **EfTagRepository:** `GetByCaptureId` empty + scoped; `AddAsync` + read-back; `RemoveAsync` deletes match; `RemoveAsync` no-op when tag absent.

## Test plan

- [x] `dotnet test … --filter "FullyQualifiedName~Repositories.EfChannelRepositoryTests|EfSkillRunRepositoryTests|EfTagRepositoryTests"` — 17/17 green
- [x] Full `FlowHub.Persistence.Tests` suite — 55/55 green (38 prior + 17 new)
- [x] Cobertura: each of the three repos at 100 % line; assembly 76.4 % → 84.9 %

## Notes

- Pattern mirrors the existing `EfCaptureRepositoryTests` — `[Collection(PostgresGroup.Name)]` + `fixture.CreateFreshDbAsync(seedCatalog: false)` per test.
- `SkillRun` (FK to Skill via `SkillName`, FK to Capture cascade) and `Tag` (FK to Capture cascade) require parent rows to exist. Each test seeds them via `EfSkillRepository.UpsertAsync` + `EfCaptureRepository.AddAsync`.
- Remaining `FlowHub.Persistence` gaps (per #126 §B) are now: `PersistenceServiceCollectionExtensions.cs` (23 lines, DI wiring), `FlowHubDbContextFactory.cs` (8 lines, EF design-time factory), `CaptureQueryBuilder` / `FlowHubDbContext` / `EfIntegrationRepository` / `EfCaptureService` branch tails (~22 lines). The first two are good `[ExcludeFromCodeCoverage]` candidates; the branch tails are one PR each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)