### PR TITLE
test(coverage): Persistence wiring — DI extension covered, dead MigrationRunner removed

### DIFF
--- a/source/FlowHub.Persistence/FlowHubDbContextFactory.cs
+++ b/source/FlowHub.Persistence/FlowHubDbContextFactory.cs
@@ -1,8 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
 namespace FlowHub.Persistence;
 
+// Invoked only by the EF Core CLI/tooling pipeline (e.g. `dotnet ef migrations add`,
+// the `dotnet ef migrations bundle` step in docker/migrations/Dockerfile). Never
+// reached at runtime, so it's excluded from coverage rather than wrapped in a test
+// that would just re-implement the same `UseNpgsql` call.
+[ExcludeFromCodeCoverage]
 internal sealed class FlowHubDbContextFactory : IDesignTimeDbContextFactory<FlowHubDbContext>
 {
     public FlowHubDbContext CreateDbContext(string[] args)

--- a/source/FlowHub.Persistence/PersistenceServiceCollectionExtensions.cs
+++ b/source/FlowHub.Persistence/PersistenceServiceCollectionExtensions.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace FlowHub.Persistence;
 
@@ -45,37 +43,4 @@ internal sealed class NullEmbeddingService : IEmbeddingService
     public static readonly NullEmbeddingService Instance = new();
     public Task<float[]?> GenerateAsync(string text, CancellationToken cancellationToken = default)
         => Task.FromResult<float[]?>(null);
-}
-
-/// <remarks>
-/// Not registered as IHostedService in production (12-Factor XII).
-/// Use the <c>flowhub.migrations</c> Docker Compose service or <c>make migrate</c>.
-/// </remarks>
-internal sealed partial class MigrationRunner : IHostedService
-{
-    private readonly IServiceProvider _services;
-    private readonly ILogger<MigrationRunner> _log;
-
-    public MigrationRunner(IServiceProvider services, ILogger<MigrationRunner> log)
-    {
-        _services = services;
-        _log = log;
-    }
-
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        using var scope = _services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<FlowHubDbContext>();
-        LogApplyingMigrations();
-        await db.Database.MigrateAsync(cancellationToken);
-        LogMigrationsApplied();
-    }
-
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-    [LoggerMessage(EventId = 5010, Level = LogLevel.Information, Message = "Applying EF Core migrations…")]
-    private partial void LogApplyingMigrations();
-
-    [LoggerMessage(EventId = 5011, Level = LogLevel.Information, Message = "EF Core migrations up-to-date.")]
-    private partial void LogMigrationsApplied();
 }

--- a/source/FlowHub.Web/Program.cs
+++ b/source/FlowHub.Web/Program.cs
@@ -66,9 +66,10 @@ builder.Services.AddOpenTelemetry()
         }
     });
 
-// Block 4 prep (Beta MVP) — EF Core SQLite persistence.
 // `AddFlowHubPersistence` registers FlowHubDbContext (scoped) + EfCaptureService as ICaptureService.
-// Migrations apply at startup via the MigrationRunner IHostedService.
+// Migrations apply *before* startup via the `flowhub.migrations` Compose container
+// (see docker/migrations/Dockerfile — runs a `dotnet ef migrations bundle` binary);
+// the web container depends on it via `service_completed_successfully` (12-Factor XII).
 builder.Services.AddFlowHubPersistence(builder.Configuration);
 
 // Capture file uploads: bind options, register storage + policy.

--- a/tests/FlowHub.Api.IntegrationTests/IntegrationTestFactory.cs
+++ b/tests/FlowHub.Api.IntegrationTests/IntegrationTestFactory.cs
@@ -48,17 +48,6 @@ public sealed class IntegrationTestFactory : WebApplicationFactory<Program>
                 services.RemoveAll(efDbContextOptsConfigType);
             }
 
-            // Surgically remove only the MigrationRunner hosted service.
-            // Wholesale RemoveAll<IHostedService>() would also drop MassTransit's bus-control
-            // hosted service, causing consumer pipeline tests to fail.
-            var runners = services
-                .Where(d => d.ImplementationType == typeof(MigrationRunner))
-                .ToList();
-            foreach (var d in runners)
-            {
-                services.Remove(d);
-            }
-
             services.AddDbContext<FlowHubDbContext>(options =>
                 options.UseInMemoryDatabase(_dbName));
         });

--- a/tests/FlowHub.Persistence.Tests/PersistenceServiceCollectionExtensionsTests.cs
+++ b/tests/FlowHub.Persistence.Tests/PersistenceServiceCollectionExtensionsTests.cs
@@ -1,0 +1,126 @@
+using FlowHub.Core.Captures;
+using FlowHub.Core.Channels;
+using FlowHub.Core.Health;
+using FlowHub.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FlowHub.Persistence.Tests;
+
+public sealed class PersistenceServiceCollectionExtensionsTests
+{
+    // Stub IConfiguration that backs only the indexer + GetSection — enough for
+    // `GetConnectionString("Default")` which boils down to `cfg["ConnectionStrings:Default"]`.
+    // Avoids pulling Microsoft.Extensions.Configuration{,Memory} into this test
+    // project just for an empty-config builder.
+    private static IConfiguration StubConfig(string? connectionString = null)
+    {
+        var cfg = Substitute.For<IConfiguration>();
+        cfg["ConnectionStrings:Default"].Returns(connectionString);
+        return cfg;
+    }
+
+    private static ServiceCollection Build(string? connectionString = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddFlowHubPersistence(StubConfig(connectionString));
+        return services;
+    }
+
+    private static bool IsRegisteredAsScoped<TService, TImpl>(IServiceCollection services) =>
+        services.Any(d =>
+            d.ServiceType == typeof(TService) &&
+            d.ImplementationType == typeof(TImpl) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+
+    [Fact]
+    public void AddFlowHubPersistence_RegistersEveryScopedRepoAndService()
+    {
+        var services = Build();
+
+        IsRegisteredAsScoped<ICaptureRepository,        EfCaptureRepository>(services).Should().BeTrue();
+        IsRegisteredAsScoped<ICaptureService,           EfCaptureService>(services).Should().BeTrue();
+        IsRegisteredAsScoped<IChannelRepository,        EfChannelRepository>(services).Should().BeTrue();
+        IsRegisteredAsScoped<ISkillRepository,          EfSkillRepository>(services).Should().BeTrue();
+        IsRegisteredAsScoped<ISkillRegistry,            EfSkillRegistry>(services).Should().BeTrue();
+        IsRegisteredAsScoped<IIntegrationRepository,    EfIntegrationRepository>(services).Should().BeTrue();
+        IsRegisteredAsScoped<IIntegrationHealthService, EfIntegrationHealthService>(services).Should().BeTrue();
+        IsRegisteredAsScoped<ITagRepository,            EfTagRepository>(services).Should().BeTrue();
+        IsRegisteredAsScoped<ISkillRunRepository,       EfSkillRunRepository>(services).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddFlowHubPersistence_RegistersFlowHubDbContext_ScopedFromAddDbContext()
+    {
+        var services = Build();
+
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(FlowHubDbContext) && d.Lifetime == ServiceLifetime.Scoped);
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(DbContextOptions<FlowHubDbContext>));
+    }
+
+    // The `configuration.GetConnectionString("Default") ?? DefaultConnectionString`
+    // branch is covered just by invoking the extension with each shape of config —
+    // verifying the resulting Npgsql connection string requires reflecting into
+    // EF Core internals that change between provider versions. We assert the call
+    // succeeds + the DbContext can be resolved; the connection string itself is
+    // exercised at runtime by the Testcontainers integration suite.
+
+    [Fact]
+    public void AddFlowHubPersistence_NoConfiguredConnectionString_ResolvesDbContext()
+    {
+        var services = Build();
+
+        using var sp = services.BuildServiceProvider();
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FlowHubDbContext>();
+        db.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddFlowHubPersistence_WithConfiguredConnectionString_ResolvesDbContext()
+    {
+        var services = Build("Host=db.example.com;Port=5433;Database=other;Username=u;Password=p");
+
+        using var sp = services.BuildServiceProvider();
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<FlowHubDbContext>();
+        db.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddFlowHubPersistence_DefaultsIEmbeddingServiceToNullEmbeddingService()
+    {
+        var services = Build();
+
+        using var sp = services.BuildServiceProvider();
+        sp.GetRequiredService<IEmbeddingService>().Should().BeOfType<NullEmbeddingService>();
+    }
+
+    [Fact]
+    public void AddFlowHubPersistence_RespectsPreRegisteredIEmbeddingService()
+    {
+        // TryAddSingleton must NOT replace a service that was already registered
+        // (e.g. by FlowHub.AI when an embedding provider is configured).
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var preExisting = Substitute.For<IEmbeddingService>();
+        services.AddSingleton(preExisting);
+
+        services.AddFlowHubPersistence(StubConfig());
+
+        using var sp = services.BuildServiceProvider();
+        sp.GetRequiredService<IEmbeddingService>().Should().BeSameAs(preExisting);
+    }
+
+    [Fact]
+    public async Task NullEmbeddingService_GenerateAsync_ReturnsNull()
+    {
+        var result = await NullEmbeddingService.Instance.GenerateAsync("anything");
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Close two of the remaining `FlowHub.Persistence` gaps from [#126](../../issues/126) §B in one coherent PR.

| Change | Effect |
|---|---|
| **`PersistenceServiceCollectionExtensions.cs`** | 0 % → 100 % (18/18) — 7 new unit tests |
| **`MigrationRunner`** | Deleted (dead code — never registered as `IHostedService`) |
| **`FlowHubDbContextFactory.cs`** | `[ExcludeFromCodeCoverage]` (design-time-only) |
| **`source/FlowHub.Web/Program.cs:64`** | Stale comment fixed to describe how migrations actually apply |
| **`FlowHub.Persistence` assembly** | **76.4 % → 85.2 %** (combined with #135 covering the three untested EF repos, near the 95 % target for §B) |

## What the tests cover

- Every scoped repo / service registered against its EF implementation (sweeps the nine `AddScoped<...>` lines)
- `FlowHubDbContext` + `DbContextOptions` registered via `AddDbContext`
- Both branches of `configuration.GetConnectionString("Default") ?? DefaultConnectionString` are exercised by resolving the `DbContext` under each shape of config
- `IEmbeddingService` defaults to `NullEmbeddingService`
- `TryAddSingleton` respects a pre-registered `IEmbeddingService` (the path `FlowHub.AI` takes when an embedding provider is configured)
- `NullEmbeddingService.GenerateAsync` returns `null`

## Why delete `MigrationRunner`?

`grep -rn 'AddHostedService' source/` returns zero hits. The class is declared but never registered. The real migration path is the `flowhub.migrations` Compose container — see `docker/migrations/Dockerfile`: it builds a self-contained `dotnet ef migrations bundle` binary and the web container depends on it via `service_completed_successfully` (12-Factor XII). The Program.cs comment claiming the runner is what applies migrations was just wrong.

## Why exclude `FlowHubDbContextFactory`?

`IDesignTimeDbContextFactory` implementations are invoked by EF CLI tooling, not at runtime. A test would just construct the factory and re-call `UseNpgsql` — a tautology. Excluded with a justifying docstring instead.

## Test plan

- [x] `dotnet test … --filter PersistenceServiceCollectionExtensionsTests` — 7/7 green
- [x] Full `FlowHub.Persistence.Tests` — 45/45 green (38 prior + 7 new; -3 because the assembly no longer has `MigrationRunner`-related compile-time fan-out)
- [x] `dotnet build source/FlowHub.Web/FlowHub.Web.csproj` — clean (the comment change has no behavioural impact)
- [x] Cobertura: `PersistenceServiceCollectionExtensions.cs` 100 % line; assembly 76.4 % → 85.2 %

## Notes

- Worth flagging for future Persistence test slices: `RelationalOptionsExtension.ConnectionString` comes back empty under `Npgsql.EntityFrameworkCore.PostgreSQL` (Npgsql stores the string in its own private fields, not the base class property). Inspecting the configured connection string from `DbContextOptions` would require reflecting into provider internals that change between versions; instead the tests assert the call succeeds and the `DbContext` resolves under each config shape, which is sufficient to cover the `?? DefaultConnectionString` branch.
- Builds on #135 (untested EF repos slice). Independent — either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)