### PR TITLE
test(quality): Persistence ratchet (1/2) — service-level + Tag/SkillRun/Channel tests (part of #96)

### DIFF
--- a/tests/FlowHub.Persistence.Tests/EfCaptureServiceAttachmentTests.cs
+++ b/tests/FlowHub.Persistence.Tests/EfCaptureServiceAttachmentTests.cs
@@ -1,4 +1,5 @@
 using FlowHub.Core.Captures;
+using FlowHub.Core.Events;
 using MassTransit;
 
 namespace FlowHub.Persistence.Tests;
@@ -47,5 +48,93 @@ public class EfCaptureServiceAttachmentTests
             .Should().ThrowAsync<InvalidOperationException>();
 
         await storage.Received(1).DeleteAsync("2026/05/abc123.pdf", Arg.Any<CancellationToken>());
+    }
+
+    // --- Pin previously-uncovered behaviour (issue #96 ratchet) -------------
+
+    [Fact]
+    public async Task SubmitAsync_WithAttachment_PublishesCaptureCreatedWithHasAttachmentTrue()
+    {
+        var repo = Substitute.For<ICaptureRepository>();
+        repo.AddAsync(Arg.Any<Capture>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<Capture>()));
+        var storage = Substitute.For<IAttachmentStorage>();
+        storage.SaveAsync(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("2026/05/abc.pdf");
+        var publish = Substitute.For<IPublishEndpoint>();
+        var sut = new EfCaptureService(repo, publish, storage);
+
+        using var bytes = new MemoryStream(new byte[3]);
+        var input = new AttachmentInput { Content = bytes, FileName = "x.pdf", ContentType = "application/pdf", SizeBytes = 3 };
+
+        await sut.SubmitAsync(null, ChannelKind.Api, input);
+
+        await publish.Received(1).Publish(
+            Arg.Is<CaptureCreated>(m => m.HasAttachment == true),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SubmitAsync_WithNullAttachment_DelegatesToContentOverload()
+    {
+        // Verifies the early-return-on-null-attachment branch: the storage is never touched,
+        // and the published message has HasAttachment == false.
+        var repo = Substitute.For<ICaptureRepository>();
+        repo.AddAsync(Arg.Any<Capture>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<Capture>()));
+        var storage = Substitute.For<IAttachmentStorage>();
+        var publish = Substitute.For<IPublishEndpoint>();
+        var sut = new EfCaptureService(repo, publish, storage);
+
+        await sut.SubmitAsync("plain content", ChannelKind.Web, attachment: null);
+
+        await storage.DidNotReceive().SaveAsync(
+            Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await publish.Received(1).Publish(
+            Arg.Is<CaptureCreated>(m => m.HasAttachment == false),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SubmitAsync_NullContentAndNullAttachment_ThrowsArgumentNullException()
+    {
+        var sut = new EfCaptureService(
+            Substitute.For<ICaptureRepository>(),
+            Substitute.For<IPublishEndpoint>(),
+            Substitute.For<IAttachmentStorage>());
+
+        await sut.Invoking(s => s.SubmitAsync(null, ChannelKind.Web, attachment: null))
+            .Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SubmitAsync_WithAttachment_StripsDirectoryPartsFromFileName()
+    {
+        // FileName goes through Path.GetFileName; an upload that tried to smuggle a path
+        // separator must end up using only the basename in BOTH the stored Attachment.FileName
+        // and the Capture.Content. Without this, the `Path.GetFileName(attachment.FileName)`
+        // mutant (replace with `attachment.FileName`) survives.
+        var repo = Substitute.For<ICaptureRepository>();
+        repo.AddAsync(Arg.Any<Capture>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<Capture>()));
+        var storage = Substitute.For<IAttachmentStorage>();
+        storage.SaveAsync(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("2026/05/abc.pdf");
+        var publish = Substitute.For<IPublishEndpoint>();
+        var sut = new EfCaptureService(repo, publish, storage);
+
+        using var bytes = new MemoryStream(new byte[1]);
+        var input = new AttachmentInput
+        {
+            Content = bytes,
+            FileName = "subdir/innocent.pdf",
+            ContentType = "application/pdf",
+            SizeBytes = 1,
+        };
+
+        var capture = await sut.SubmitAsync(null, ChannelKind.Web, input);
+
+        capture.Content.Should().Be("innocent.pdf");
+        capture.Attachment!.FileName.Should().Be("innocent.pdf");
     }
 }

--- a/tests/FlowHub.Persistence.Tests/EfCaptureServiceTests.cs
+++ b/tests/FlowHub.Persistence.Tests/EfCaptureServiceTests.cs
@@ -188,4 +188,150 @@ public sealed class EfCaptureServiceTests
             Arg.Is<Capture>(c => c.Stage == LifecycleStage.Raw && c.FailureReason == null),
             Arg.Any<CancellationToken>());
     }
+
+    // --- Pin previously-untested public methods (issue #96 ratchet) ---------
+
+    [Fact]
+    public async Task GetAllAsync_DelegatesToRepository()
+    {
+        var (repo, sut, _) = Build();
+        var caps = new[] { MakeCapture(), MakeCapture() };
+        repo.GetAllAsync(Arg.Any<CancellationToken>()).Returns(caps);
+
+        var result = await sut.GetAllAsync();
+
+        result.Should().BeEquivalentTo(caps);
+        await repo.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    // --- Pin SubmitAsync published-message field mapping --------------------
+    // Existing test only asserted the CaptureId; the field-mapping mutants
+    // (Content, Source, CreatedAt → other values / null) survive that.
+
+    [Fact]
+    public async Task SubmitAsync_PublishesAllFieldsFromSavedCapture()
+    {
+        var (repo, sut, ep) = Build();
+        var saved = MakeCapture(stage: LifecycleStage.Raw) with { Source = ChannelKind.Api };
+        repo.AddAsync(Arg.Any<Capture>(), Arg.Any<CancellationToken>()).Returns(saved);
+
+        await sut.SubmitAsync("https://example.com/article", ChannelKind.Api);
+
+        await ep.Received(1).Publish(
+            Arg.Is<CaptureCreated>(m =>
+                m.CaptureId == saved.Id &&
+                m.Content == saved.Content &&
+                m.Source == saved.Source &&
+                m.CreatedAt == saved.CreatedAt),
+            Arg.Any<CancellationToken>());
+    }
+
+    // --- Pin Mark*Async null-coalescing semantics ---------------------------
+    // The Mark*Async overloads preserve existing values when the caller passes
+    // null for an optional param (e.g. `title ?? capture.Title`). Without these
+    // tests every `?? capture.X` mutant survives.
+
+    [Fact]
+    public async Task MarkClassifiedAsync_WhenOptionalsAreNull_PreservesExistingValues()
+    {
+        var (repo, sut, _) = Build();
+        var id = Guid.NewGuid();
+        var existing = MakeCapture(id) with
+        {
+            Title = "existing title",
+            VikunjaProject = "existing project",
+            EnrichmentDescription = "existing description",
+            ClassifierTrace = new FlowHub.Core.Classification.ClassifierTrace(
+                FlowHub.Core.Classification.ClassifierKind.Keyword, 1),
+        };
+        repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(existing);
+
+        await sut.MarkClassifiedAsync(id, "Wallabag");
+
+        await repo.Received(1).UpdateAsync(
+            Arg.Is<Capture>(c =>
+                c.Stage == LifecycleStage.Classified &&
+                c.MatchedSkill == "Wallabag" &&
+                c.Title == existing.Title &&
+                c.VikunjaProject == existing.VikunjaProject &&
+                c.EnrichmentDescription == existing.EnrichmentDescription &&
+                c.ClassifierTrace == existing.ClassifierTrace),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MarkClassifiedAsync_WithExplicitValues_OverwritesExisting()
+    {
+        var (repo, sut, _) = Build();
+        var id = Guid.NewGuid();
+        repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(MakeCapture(id) with
+        {
+            Title = "old", VikunjaProject = "old-proj", EnrichmentDescription = "old-desc",
+        });
+        var trace = new FlowHub.Core.Classification.ClassifierTrace(
+            FlowHub.Core.Classification.ClassifierKind.Ai, 42, "anthropic", "claude-3");
+
+        await sut.MarkClassifiedAsync(id, "Vikunja", "new title", "new-proj", "new desc", trace);
+
+        await repo.Received(1).UpdateAsync(
+            Arg.Is<Capture>(c =>
+                c.MatchedSkill == "Vikunja" &&
+                c.Title == "new title" &&
+                c.VikunjaProject == "new-proj" &&
+                c.EnrichmentDescription == "new desc" &&
+                c.ClassifierTrace == trace),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MarkCompletedAsync_WhenExternalRefIsNull_PreservesExistingValue()
+    {
+        var (repo, sut, _) = Build();
+        var id = Guid.NewGuid();
+        var existing = MakeCapture(id, LifecycleStage.Routed, "Wallabag") with { ExternalRef = "existing-ref" };
+        repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(existing);
+
+        await sut.MarkCompletedAsync(id, null);
+
+        await repo.Received(1).UpdateAsync(
+            Arg.Is<Capture>(c => c.Stage == LifecycleStage.Completed && c.ExternalRef == existing.ExternalRef),
+            Arg.Any<CancellationToken>());
+    }
+
+    // --- Pin "Capture not found" KeyNotFoundException for each Mark*Async ----
+    // Without these every `?? throw new KeyNotFoundException(...)` mutant survives
+    // (replacement could drop the throw or change the message).
+
+    public static IEnumerable<object[]> NotFoundCases() => new[]
+    {
+        new object[] { "MarkClassifiedAsync" },
+        new object[] { "MarkRoutedAsync" },
+        new object[] { "MarkCompletedAsync" },
+        new object[] { "MarkOrphanAsync" },
+        new object[] { "MarkUnhandledAsync" },
+        new object[] { "ResetForRetryAsync" },
+    };
+
+    [Theory]
+    [MemberData(nameof(NotFoundCases))]
+    public async Task MarkMethods_WhenCaptureMissing_ThrowsKeyNotFoundWithIdInMessage(string method)
+    {
+        var (repo, sut, _) = Build();
+        var id = Guid.NewGuid();
+        repo.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((Capture?)null);
+
+        Func<Task> act = method switch
+        {
+            "MarkClassifiedAsync" => () => sut.MarkClassifiedAsync(id, "Wallabag"),
+            "MarkRoutedAsync"     => () => sut.MarkRoutedAsync(id),
+            "MarkCompletedAsync"  => () => sut.MarkCompletedAsync(id, "ref"),
+            "MarkOrphanAsync"     => () => sut.MarkOrphanAsync(id, "reason"),
+            "MarkUnhandledAsync"  => () => sut.MarkUnhandledAsync(id, "reason"),
+            "ResetForRetryAsync"  => () => sut.ResetForRetryAsync(id),
+            _ => throw new InvalidOperationException(method),
+        };
+
+        var ex = await act.Should().ThrowAsync<KeyNotFoundException>();
+        ex.Which.Message.Should().Contain(id.ToString());
+    }
 }

--- a/tests/FlowHub.Persistence.Tests/FilesystemAttachmentStorageTests.cs
+++ b/tests/FlowHub.Persistence.Tests/FilesystemAttachmentStorageTests.cs
@@ -55,6 +55,73 @@ public class FilesystemAttachmentStorageTests : IDisposable
         buffer.ToArray().Should().Equal(bytes);
     }
 
+    // --- Pin previously-uncovered behaviour (issue #96 ratchet) -------------
+
+    [Fact]
+    public async Task OpenReadAsync_WhenCancelled_Throws()
+    {
+        // Pins the `cancellationToken.ThrowIfCancellationRequested()` call —
+        // without this the statement-removal mutant survives.
+        var sut = NewSut();
+        var relative = await sut.SaveAsync(new MemoryStream(new byte[] { 1 }), "x.pdf", "application/pdf");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = () => sut.OpenReadAsync(relative, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task SaveAsync_FileNameWithoutExtension_ProducesEmptyExtensionInRelativePath()
+    {
+        // Pins the `Path.GetExtension(Path.GetFileName(fileName))` chain — the
+        // relative path's tail is the bare GUID when no extension is present.
+        var sut = NewSut();
+        using var stream = new MemoryStream(new byte[] { 9 });
+
+        var relative = await sut.SaveAsync(stream, "no-extension", "application/octet-stream");
+
+        relative.Should().MatchRegex(@"^\d{4}/\d{2}/[0-9a-f]{32}$");
+    }
+
+    [Fact]
+    public async Task SaveAsync_FileNameWithDirectoryParts_UsesOnlyBaseNameExtension()
+    {
+        // Pins the `Path.GetFileName(fileName)` part of the chain — a path with
+        // separators must still produce a relative path whose extension matches
+        // the *basename* (not e.g. an extension on the directory part).
+        var sut = NewSut();
+        using var stream = new MemoryStream(new byte[] { 1 });
+
+        var relative = await sut.SaveAsync(stream, "dir.with.dots/actual-file.pdf", "application/pdf");
+
+        relative.Should().EndWith(".pdf");
+    }
+
+    [Fact]
+    public async Task SaveAsync_UsesYearAndMonthFromUtcNow_InRelativePath()
+    {
+        // Pins the year/month string formatting: the relative path's first two
+        // segments must be the current UTC year (4 digits) and month (2 digits).
+        var sut = NewSut();
+        using var stream = new MemoryStream(new byte[] { 1 });
+        var before = DateTimeOffset.UtcNow;
+
+        var relative = await sut.SaveAsync(stream, "x.pdf", "application/pdf");
+
+        var after = DateTimeOffset.UtcNow;
+        var segments = relative.Split('/');
+        segments.Should().HaveCount(3);
+        // The year/month must match either the before or after snapshot (the SUT
+        // takes its own UtcNow internally, which sits in [before, after]).
+        var actualYear = int.Parse(segments[0], System.Globalization.CultureInfo.InvariantCulture);
+        var actualMonth = int.Parse(segments[1], System.Globalization.CultureInfo.InvariantCulture);
+        (actualYear, actualMonth).Should().BeOneOf(
+            (before.Year, before.Month),
+            (after.Year, after.Month));
+    }
+
     private FilesystemAttachmentStorage NewSut()
     {
         var env = Substitute.For<IHostEnvironment>();

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfChannelRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfChannelRepositoryTests.cs
@@ -1,0 +1,102 @@
+using FlowHub.Core.Captures;
+using FlowHub.Core.Channels;
+using FlowHub.Core.Health;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfChannelRepositoryTests(PostgresFixture fixture)
+{
+    private static Channel NewChannel(
+        string name = "Web",
+        ChannelKind kind = ChannelKind.Web,
+        bool isEnabled = true,
+        HealthStatus status = HealthStatus.Healthy,
+        DateTimeOffset? lastActiveAt = null) =>
+        new(name, kind, isEnabled, status, lastActiveAt);
+
+    [Fact]
+    public async Task UpsertAsync_NewName_InsertsRow()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfChannelRepository(db);
+
+        await sut.UpsertAsync(NewChannel("Web", ChannelKind.Web, true, HealthStatus.Healthy));
+
+        var all = await sut.GetAllAsync();
+        all.Should().ContainSingle(c => c.Name == "Web");
+    }
+
+    [Fact]
+    public async Task UpsertAsync_ExistingName_UpdatesAllFields()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfChannelRepository(db);
+        await sut.UpsertAsync(NewChannel("Web", ChannelKind.Web, true, HealthStatus.Healthy, null));
+        var when = new DateTimeOffset(2026, 6, 22, 12, 0, 0, TimeSpan.Zero);
+
+        await sut.UpsertAsync(NewChannel("Web", ChannelKind.Api, isEnabled: false, status: HealthStatus.Degraded, lastActiveAt: when));
+
+        var fetched = await sut.GetByNameAsync("Web");
+        fetched.Should().NotBeNull();
+        fetched!.Kind.Should().Be(ChannelKind.Api);
+        fetched.IsEnabled.Should().BeFalse();
+        fetched.Status.Should().Be(HealthStatus.Degraded);
+        fetched.LastActiveAt.Should().Be(when);
+
+        // And there's still only one row.
+        (await sut.GetAllAsync()).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_UnknownName_ReturnsNull()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfChannelRepository(db);
+
+        (await sut.GetByNameAsync("Nope")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_KnownName_RoundTripsAllFields()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfChannelRepository(db);
+        var when = new DateTimeOffset(2026, 6, 22, 12, 0, 0, TimeSpan.Zero);
+        await sut.UpsertAsync(NewChannel("Telegram", ChannelKind.Telegram, isEnabled: false, status: HealthStatus.Down, lastActiveAt: when));
+
+        var found = await sut.GetByNameAsync("Telegram");
+
+        found.Should().NotBeNull();
+        found!.Name.Should().Be("Telegram");
+        found.Kind.Should().Be(ChannelKind.Telegram);
+        found.IsEnabled.Should().BeFalse();
+        found.Status.Should().Be(HealthStatus.Down);
+        found.LastActiveAt.Should().Be(when);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsEveryUpsertedChannel()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfChannelRepository(db);
+        await sut.UpsertAsync(NewChannel("Web"));
+        await sut.UpsertAsync(NewChannel("Api", ChannelKind.Api));
+        await sut.UpsertAsync(NewChannel("Telegram", ChannelKind.Telegram));
+
+        var all = await sut.GetAllAsync();
+
+        all.Select(c => c.Name).Should().BeEquivalentTo(new[] { "Web", "Api", "Telegram" });
+    }
+
+    [Fact]
+    public async Task GetAllAsync_EmptyDb_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfChannelRepository(db);
+
+        (await sut.GetAllAsync()).Should().BeEmpty();
+    }
+}

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRunRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRunRepositoryTests.cs
@@ -1,0 +1,161 @@
+using FlowHub.Core.Captures;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfSkillRunRepositoryTests(PostgresFixture fixture)
+{
+    // SkillRuns have an FK to Captures; the parent row must exist first.
+    private static async Task<Guid> SeedCaptureAsync(FlowHubDbContext db)
+    {
+        var captures = new EfCaptureRepository(db);
+        var cap = new Capture(Guid.NewGuid(), ChannelKind.Web, "x", DateTimeOffset.UtcNow, LifecycleStage.Raw, null);
+        await captures.AddAsync(cap);
+        return cap.Id;
+    }
+
+    private static SkillRun BuildRun(
+        Guid captureId,
+        string skillName = "Books",
+        DateTimeOffset? startedAt = null,
+        bool success = true,
+        string? failureReason = null)
+    {
+        var started = startedAt ?? DateTimeOffset.UtcNow;
+        return new SkillRun(
+            Guid.NewGuid(),
+            skillName,
+            captureId,
+            started,
+            started.AddSeconds(1),
+            success,
+            failureReason);
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsSkillRun_AndReturnsInput()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+        var run = BuildRun(captureId);
+
+        var saved = await sut.AddAsync(run);
+
+        saved.Should().Be(run);
+
+        var found = await sut.GetByCaptureIdAsync(captureId);
+        found.Should().ContainSingle(r => r.Id == run.Id);
+    }
+
+    [Fact]
+    public async Task AddAsync_PreservesAllFields()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+        var started = new DateTimeOffset(2026, 6, 22, 17, 30, 0, TimeSpan.Zero);
+        var run = BuildRun(
+            captureId: captureId,
+            skillName: "Articles",
+            startedAt: started,
+            success: false,
+            failureReason: "404 from API");
+
+        await sut.AddAsync(run);
+
+        var found = (await sut.GetByCaptureIdAsync(captureId)).Single();
+        found.SkillName.Should().Be("Articles");
+        found.Success.Should().BeFalse();
+        found.FailureReason.Should().Be("404 from API");
+        found.StartedAt.Should().Be(started);
+        found.CompletedAt.Should().Be(started.AddSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_OnlyReturnsRunsForRequestedCapture()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+        var captureA = await SeedCaptureAsync(db);
+        var captureB = await SeedCaptureAsync(db);
+        await sut.AddAsync(BuildRun(captureA, skillName: "Books"));
+        await sut.AddAsync(BuildRun(captureB, skillName: "Articles"));
+
+        var result = await sut.GetByCaptureIdAsync(captureA);
+
+        result.Should().ContainSingle().Which.SkillName.Should().Be("Books");
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_OrdersByStartedAtDescending()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+        var t0 = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        await sut.AddAsync(BuildRun(captureId, startedAt: t0));
+        await sut.AddAsync(BuildRun(captureId, startedAt: t0.AddHours(2)));
+        await sut.AddAsync(BuildRun(captureId, startedAt: t0.AddHours(1)));
+
+        var result = await sut.GetByCaptureIdAsync(captureId);
+
+        result.Select(r => r.StartedAt).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task GetBySkillNameAsync_OnlyReturnsRunsForRequestedSkill()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+        await sut.AddAsync(BuildRun(captureId, skillName: "Books"));
+        await sut.AddAsync(BuildRun(captureId, skillName: "Books"));
+        await sut.AddAsync(BuildRun(captureId, skillName: "Articles"));
+
+        var result = await sut.GetBySkillNameAsync("Books");
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(r => r.SkillName == "Books");
+    }
+
+    [Fact]
+    public async Task GetBySkillNameAsync_OrdersByStartedAtDescending()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+        var t0 = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        await sut.AddAsync(BuildRun(captureId, skillName: "Books", startedAt: t0));
+        await sut.AddAsync(BuildRun(captureId, skillName: "Books", startedAt: t0.AddDays(2)));
+        await sut.AddAsync(BuildRun(captureId, skillName: "Books", startedAt: t0.AddDays(1)));
+
+        var result = await sut.GetBySkillNameAsync("Books");
+
+        result.Select(r => r.StartedAt).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_NoMatches_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+
+        var result = await sut.GetByCaptureIdAsync(Guid.NewGuid());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetBySkillNameAsync_NoMatches_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: true);
+        var sut = new EfSkillRunRepository(db);
+
+        var result = await sut.GetBySkillNameAsync("NotASkill");
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfTagRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfTagRepositoryTests.cs
@@ -1,0 +1,117 @@
+using FlowHub.Core.Captures;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfTagRepositoryTests(PostgresFixture fixture)
+{
+    private static async Task<Guid> SeedCaptureAsync(FlowHubDbContext db)
+    {
+        // Tags have a FK to Captures, so the parent row must exist first.
+        var captures = new EfCaptureRepository(db);
+        var cap = new Capture(Guid.NewGuid(), ChannelKind.Web, "x", DateTimeOffset.UtcNow, LifecycleStage.Raw, null);
+        await captures.AddAsync(cap);
+        return cap.Id;
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsTag_AndGetByCaptureIdReturnsIt()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfTagRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+
+        await sut.AddAsync(captureId, "billing");
+
+        var result = await sut.GetByCaptureIdAsync(captureId);
+        result.Should().ContainSingle().Which.Should().Be("billing");
+    }
+
+    [Fact]
+    public async Task AddAsync_MultipleTags_AllReturnedForSameCaptureId()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfTagRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+
+        await sut.AddAsync(captureId, "billing");
+        await sut.AddAsync(captureId, "urgent");
+        await sut.AddAsync(captureId, "client-x");
+
+        var result = await sut.GetByCaptureIdAsync(captureId);
+        result.Should().BeEquivalentTo(new[] { "billing", "urgent", "client-x" });
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_OnlyReturnsTagsForRequestedCapture()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfTagRepository(db);
+        var captureA = await SeedCaptureAsync(db);
+        var captureB = await SeedCaptureAsync(db);
+        await sut.AddAsync(captureA, "billing");
+        await sut.AddAsync(captureB, "support");
+
+        var result = await sut.GetByCaptureIdAsync(captureA);
+
+        result.Should().ContainSingle().Which.Should().Be("billing");
+    }
+
+    [Fact]
+    public async Task GetByCaptureIdAsync_NoTags_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfTagRepository(db);
+
+        var result = await sut.GetByCaptureIdAsync(Guid.NewGuid());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_RemovesMatchingTag_LeavesOthers()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfTagRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+        await sut.AddAsync(captureId, "billing");
+        await sut.AddAsync(captureId, "urgent");
+
+        await sut.RemoveAsync(captureId, "billing");
+
+        var result = await sut.GetByCaptureIdAsync(captureId);
+        result.Should().ContainSingle().Which.Should().Be("urgent");
+    }
+
+    [Fact]
+    public async Task RemoveAsync_NonExistentTag_DoesNotThrow_AndDoesNotChangeOthers()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfTagRepository(db);
+        var captureId = await SeedCaptureAsync(db);
+        await sut.AddAsync(captureId, "keep");
+
+        var act = () => sut.RemoveAsync(captureId, "never-there");
+
+        await act.Should().NotThrowAsync();
+        (await sut.GetByCaptureIdAsync(captureId)).Should().ContainSingle().Which.Should().Be("keep");
+    }
+
+    [Fact]
+    public async Task RemoveAsync_OnlyTouchesRequestedCaptureId()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfTagRepository(db);
+        var captureA = await SeedCaptureAsync(db);
+        var captureB = await SeedCaptureAsync(db);
+        await sut.AddAsync(captureA, "shared");
+        await sut.AddAsync(captureB, "shared");
+
+        await sut.RemoveAsync(captureA, "shared");
+
+        (await sut.GetByCaptureIdAsync(captureA)).Should().BeEmpty();
+        (await sut.GetByCaptureIdAsync(captureB)).Should().ContainSingle().Which.Should().Be("shared");
+    }
+}


### PR DESCRIPTION
Part 1 of 2 for #96. Split from #137 so each half stays under the 800-line diff-scope guard.

## Cluster A — covers the highest-impact gaps in service/storage code + 3 previously-zero-coverage repositories

| Test file | Tests added | Targets |
|---|---|---|
| `EfCaptureServiceTests.cs` | 5 fact + 1 theory (6 cases) | `?? capture.X` null-coalescing on every `Mark*Async`; `Mark*` not-found `KeyNotFoundException`; `GetAllAsync` delegation; full-field `CaptureCreated` mapping |
| `EfCaptureServiceAttachmentTests.cs` | 4 | `HasAttachment: true` published flag; null-attachment early return; `?? throw new ArgumentNullException(nameof(content))`; `Path.GetFileName` directory-stripping |
| `FilesystemAttachmentStorageTests.cs` | 4 | `OpenReadAsync` cancellation; file-name with/without extension; year/month UTC formatting |
| `Repositories/EfTagRepositoryTests.cs` | 7 | Multiple-tag insert; capture-scoped queries; idempotent remove; `RemoveAsync` only-touches-requested-capture |
| `Repositories/EfSkillRunRepositoryTests.cs` | 8 | Round-trips all eight columns; `OrderByDescending`; capture/skill-scoped reads |
| `Repositories/EfChannelRepositoryTests.cs` | 6 | Upsert insert + update; `ToDomain` enum round-trip; `entity is null ? null` branch |

All run against Testcontainers Postgres via the existing `PostgresFixture`. FK parents seeded where needed (`Captures` for tags / skill-runs; the seeded skill catalog for `Skills.Name` FK).

## Stryker impact (measured)
Cluster A in isolation (workflow_dispatch [run 27973683080](https://github.com/freaxnx01/FlowHub-CAS-AISE/actions/runs/27973683080)) lifted the service-layer score from 50.15% → 57.96%. Adding the three repository test files on top measured ~64-66% in a follow-up run.

This PR is **measurement-only** for the threshold — the `break` bump to 70 lives in PR B alongside the remaining repositories.