### PR TITLE
test(quality): Persistence ratchet (2/2) — Integration/Skill/ListAsync + break=70 (closes #96)

### DIFF
--- a/source/FlowHub.Persistence/stryker-config.json
+++ b/source/FlowHub.Persistence/stryker-config.json
@@ -2,7 +2,7 @@
   "stryker-config": {
     "project": "FlowHub.Persistence.csproj",
     "test-projects": ["../../tests/FlowHub.Persistence.Tests/FlowHub.Persistence.Tests.csproj"],
-    "thresholds": { "high": 80, "low": 60, "break": 45 },
+    "thresholds": { "high": 85, "low": 75, "break": 70 },
     "reporters": ["cleartext", "html", "json"],
     "mutation-level": "Standard",
     "mutate": [

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfCaptureRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfCaptureRepositoryTests.cs
@@ -242,4 +242,59 @@ public sealed class EfCaptureRepositoryTests(PostgresFixture fixture)
 
         read!.ClassifierTrace.Should().BeNull();
     }
+
+    // --- Pin previously-uncovered ListAsync filter branches (#96 ratchet) ----
+
+    [Fact]
+    public async Task ListAsync_FiltersBySearchTerm_CaseInsensitive()
+    {
+        var db = await fixture.CreateFreshDbAsync();
+        var repo = new EfCaptureRepository(db);
+        await repo.AddAsync(NewRawCapture("invoice for Acme Corp"));
+        await repo.AddAsync(NewRawCapture("random note"));
+
+        var page = await repo.ListAsync(new CaptureFilter(
+            Stages: null, Source: null, Limit: 50, Cursor: null, SearchTerm: "ACME"));
+
+        page.Items.Should().ContainSingle();
+        page.Items[0].Content.Should().Be("invoice for Acme Corp");
+    }
+
+    [Fact]
+    public async Task ListAsync_FiltersBySearchTerm_AlsoMatchesTitle()
+    {
+        var db = await fixture.CreateFreshDbAsync();
+        var repo = new EfCaptureRepository(db);
+        var c1 = NewRawCapture("content one");
+        var c2 = NewRawCapture("content two");
+        await repo.AddAsync(c1);
+        await repo.AddAsync(c2);
+        await repo.UpdateAsync(c1 with { Title = "Quarterly review", Stage = LifecycleStage.Classified, MatchedSkill = "Books" });
+        await repo.UpdateAsync(c2 with { Title = "Lunch menu", Stage = LifecycleStage.Classified, MatchedSkill = "Books" });
+
+        var page = await repo.ListAsync(new CaptureFilter(
+            Stages: null, Source: null, Limit: 50, Cursor: null, SearchTerm: "quarterly"));
+
+        page.Items.Should().ContainSingle();
+        page.Items[0].Title.Should().Be("Quarterly review");
+    }
+
+    [Fact]
+    public async Task ListAsync_FiltersByTag_ReturnsOnlyTaggedCaptures()
+    {
+        var db = await fixture.CreateFreshDbAsync();
+        var repo = new EfCaptureRepository(db);
+        var tags = new EfTagRepository(db);
+        var c1 = NewRawCapture("billing-content");
+        var c2 = NewRawCapture("other-content");
+        await repo.AddAsync(c1);
+        await repo.AddAsync(c2);
+        await tags.AddAsync(c1.Id, "billing");
+
+        var page = await repo.ListAsync(new CaptureFilter(
+            Stages: null, Source: null, Limit: 50, Cursor: null, Tag: "billing"));
+
+        page.Items.Should().ContainSingle();
+        page.Items[0].Id.Should().Be(c1.Id);
+    }
 }

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfIntegrationRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfIntegrationRepositoryTests.cs
@@ -1,0 +1,153 @@
+using FlowHub.Core.Health;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfIntegrationRepositoryTests(PostgresFixture fixture)
+{
+    [Fact]
+    public async Task UpsertAsync_NewName_InsertsRow()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+
+        await sut.UpsertAsync(new IntegrationHealth("Wallabag", HealthStatus.Healthy, null, null));
+
+        var found = await sut.GetByNameAsync("Wallabag");
+        found.Should().NotBeNull();
+        found!.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_ExistingName_UpdatesStatusAndTimingFields()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+        await sut.UpsertAsync(new IntegrationHealth("Vikunja", HealthStatus.Healthy, null, null));
+        var when = new DateTimeOffset(2026, 6, 22, 12, 0, 0, TimeSpan.Zero);
+
+        await sut.UpsertAsync(new IntegrationHealth("Vikunja", HealthStatus.Degraded, when, TimeSpan.FromMilliseconds(420)));
+
+        var found = await sut.GetByNameAsync("Vikunja");
+        found.Should().NotBeNull();
+        found!.Status.Should().Be(HealthStatus.Degraded);
+        found.LastWriteAt.Should().Be(when);
+        found.LastWriteDuration.Should().Be(TimeSpan.FromMilliseconds(420));
+
+        // Still only one row.
+        (await sut.GetAllAsync()).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_NullDuration_RoundTripsAsNull()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+
+        await sut.UpsertAsync(new IntegrationHealth("Paperless", HealthStatus.Healthy, null, LastWriteDuration: null));
+
+        var found = await sut.GetByNameAsync("Paperless");
+        found!.LastWriteDuration.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_UnknownName_ReturnsNull()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+
+        (await sut.GetByNameAsync("Nope")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsEveryUpsertedIntegration()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+        await sut.UpsertAsync(new IntegrationHealth("Wallabag", HealthStatus.Healthy, null, null));
+        await sut.UpsertAsync(new IntegrationHealth("Vikunja", HealthStatus.Degraded, null, null));
+        await sut.UpsertAsync(new IntegrationHealth("Paperless", HealthStatus.Down, null, null));
+
+        var all = await sut.GetAllAsync();
+
+        all.Select(i => i.Name).Should().BeEquivalentTo(new[] { "Wallabag", "Vikunja", "Paperless" });
+    }
+
+    [Fact]
+    public async Task AddHealthSampleAsync_PersistsSample_AndGetRecentReturnsIt()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+        await sut.UpsertAsync(new IntegrationHealth("Wallabag", HealthStatus.Healthy, null, null));
+
+        await sut.AddHealthSampleAsync("Wallabag", HealthStatus.Healthy, TimeSpan.FromMilliseconds(150));
+
+        var samples = await sut.GetRecentSamplesAsync("Wallabag", count: 10);
+        samples.Should().ContainSingle();
+        samples[0].IntegrationName.Should().Be("Wallabag");
+        samples[0].Status.Should().Be(HealthStatus.Healthy);
+        samples[0].Duration.Should().Be(TimeSpan.FromMilliseconds(150));
+    }
+
+    [Fact]
+    public async Task AddHealthSampleAsync_NullDuration_RoundTripsAsNull()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+        await sut.UpsertAsync(new IntegrationHealth("Vikunja", HealthStatus.Down, null, null));
+
+        await sut.AddHealthSampleAsync("Vikunja", HealthStatus.Down, duration: null);
+
+        var samples = await sut.GetRecentSamplesAsync("Vikunja", count: 10);
+        samples.Should().ContainSingle();
+        samples[0].Duration.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetRecentSamplesAsync_OnlyReturnsSamplesForRequestedIntegration()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+        await sut.UpsertAsync(new IntegrationHealth("Wallabag", HealthStatus.Healthy, null, null));
+        await sut.UpsertAsync(new IntegrationHealth("Vikunja", HealthStatus.Healthy, null, null));
+        await sut.AddHealthSampleAsync("Wallabag", HealthStatus.Healthy, TimeSpan.FromMilliseconds(100));
+        await sut.AddHealthSampleAsync("Vikunja", HealthStatus.Healthy, TimeSpan.FromMilliseconds(200));
+
+        var samples = await sut.GetRecentSamplesAsync("Wallabag", count: 10);
+
+        samples.Should().ContainSingle();
+        samples[0].IntegrationName.Should().Be("Wallabag");
+    }
+
+    [Fact]
+    public async Task GetRecentSamplesAsync_OrdersDescendingBySampledAt_AndRespectsCount()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+        await sut.UpsertAsync(new IntegrationHealth("Wallabag", HealthStatus.Healthy, null, null));
+        // Three samples in arbitrary order; the repo sorts SampledAt DESC and takes `count`.
+        for (var i = 0; i < 3; i++)
+        {
+            await sut.AddHealthSampleAsync("Wallabag", HealthStatus.Healthy, TimeSpan.FromMilliseconds(i + 1));
+            await Task.Delay(2); // ensure SampledAt is strictly monotonic
+        }
+
+        var samples = await sut.GetRecentSamplesAsync("Wallabag", count: 2);
+
+        samples.Should().HaveCount(2);
+        samples.Select(s => s.SampledAt).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task GetRecentSamplesAsync_NoMatches_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfIntegrationRepository(db);
+
+        var samples = await sut.GetRecentSamplesAsync("NeverUsed", count: 10);
+
+        samples.Should().BeEmpty();
+    }
+}

--- a/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRepositoryTests.cs
+++ b/tests/FlowHub.Persistence.Tests/Repositories/EfSkillRepositoryTests.cs
@@ -1,0 +1,91 @@
+using FlowHub.Core.Health;
+using FlowHub.Persistence.Repositories;
+using FlowHub.Persistence.Tests.Fixtures;
+
+namespace FlowHub.Persistence.Tests.Repositories;
+
+[Collection(PostgresGroup.Name)]
+public sealed class EfSkillRepositoryTests(PostgresFixture fixture)
+{
+    [Fact]
+    public async Task UpsertAsync_NewName_InsertsRow()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfSkillRepository(db);
+
+        await sut.UpsertAsync(new SkillHealth("Books", HealthStatus.Healthy, 0));
+
+        (await sut.GetByNameAsync("Books"))!.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_ExistingName_UpdatesStatusAndCount()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfSkillRepository(db);
+        await sut.UpsertAsync(new SkillHealth("Books", HealthStatus.Healthy, 0));
+
+        await sut.UpsertAsync(new SkillHealth("Books", HealthStatus.Degraded, 7));
+
+        var found = await sut.GetByNameAsync("Books");
+        found!.Status.Should().Be(HealthStatus.Degraded);
+        found.RoutedToday.Should().Be(7);
+        (await sut.GetAllAsync()).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_UnknownName_ReturnsNull()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfSkillRepository(db);
+
+        (await sut.GetByNameAsync("Nope")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task IncrementRoutedTodayAsync_IncrementsCount_AndPersists()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfSkillRepository(db);
+        await sut.UpsertAsync(new SkillHealth("Books", HealthStatus.Healthy, 4));
+
+        await sut.IncrementRoutedTodayAsync("Books");
+
+        var found = await sut.GetByNameAsync("Books");
+        found!.RoutedToday.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task IncrementRoutedTodayAsync_UnknownName_ThrowsKeyNotFound()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfSkillRepository(db);
+
+        var act = () => sut.IncrementRoutedTodayAsync("DoesNotExist");
+
+        var ex = await act.Should().ThrowAsync<KeyNotFoundException>();
+        ex.Which.Message.Should().Contain("DoesNotExist");
+    }
+
+    [Fact]
+    public async Task IncrementRoutedTodayAsync_TwoIncrements_AddUp()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfSkillRepository(db);
+        await sut.UpsertAsync(new SkillHealth("Books", HealthStatus.Healthy, 0));
+
+        await sut.IncrementRoutedTodayAsync("Books");
+        await sut.IncrementRoutedTodayAsync("Books");
+
+        (await sut.GetByNameAsync("Books"))!.RoutedToday.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_EmptyDb_ReturnsEmpty()
+    {
+        var db = await fixture.CreateFreshDbAsync(seedCatalog: false);
+        var sut = new EfSkillRepository(db);
+
+        (await sut.GetAllAsync()).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Part 2 of 2 for **#96** — the final cluster + the `break` ratchet that closes the issue.

Sequence: [#138](https://github.com/freaxnx01/FlowHub-CAS-AISE/pull/138) merged the service-layer + Tag/SkillRun/Channel tests; this PR adds the remaining repositories and raises the gate.

## Cluster B

| Test file | Tests added | Targets |
|---|---|---|
| `Repositories/EfIntegrationRepositoryTests.cs` | 10 | Upsert insert + update; `LastWriteDurationMs` HasValue ternary; `AddHealthSampleAsync`; `GetRecentSamplesAsync` ordering + count + null-duration round-trip |
| `Repositories/EfSkillRepositoryTests.cs` | 7 | Upsert; `IncrementRoutedTodayAsync` increment math; not-found `KeyNotFoundException` |
| `Repositories/EfCaptureRepositoryTests.cs` (+3 tests) | 3 | `ListAsync` `SearchTerm` ILike on Content / Title; `Tag` filter quantifier |

## Mutation score (CI-measured on the cumulative branch)
| Stage | Score |
|---|---|
| Baseline ([#124](https://github.com/freaxnx01/FlowHub-CAS-AISE/pull/124)) | 50.15 % |
| + Cluster A ([#138](https://github.com/freaxnx01/FlowHub-CAS-AISE/pull/138)) | ~64-66 % |
| + Cluster B (this PR) — measured on the pre-split branch | **75.38 %** |

`source/FlowHub.Persistence/stryker-config.json`: `break: 45 → 70` (just below the measured score so a regression flips the gate red), `high/low: 85/75` consistent with the other projects' Stryker configs. The canonical 60 from `templates/dotnet/` is comfortably exceeded.

**Closes #96.**