### PR TITLE
docs: examiner-sim 96/100 report + path-to-100 actions + agent-dev search guardrail

### DIFF
--- a/.claude/workflows/examiner-sim.js
+++ b/.claude/workflows/examiner-sim.js
@@ -319,6 +319,8 @@ const examinePrompt = (b) => [
   'The canonical rubric is ' + RUBRIC + ' — open it and use the EXACT scales. Your items in this bucket:',
   b.items.map((i) => '  - ' + i).join('\n'),
   '',
+  'ANKER-REGEL (rubric update June 2026): every level has concrete Bewertungsanker in ' + RUBRIC + '. A level counts as reached ONLY when ALL anchors of that level are satisfied; if the anchors are only partially met, award the NEXT-LOWER level. Read the per-level anchors for each item, choose the highest level whose anchors are fully met, and justify the choice explicitly against that level\'s anchor (and against the next level\'s unmet anchor).',
+  '',
   'Grade against the REAL rendered submission, exactly as the examiner receives it:',
   '  - PRIMARY source: the text of the 5 uploaded PDFs at ' + UPLOAD_TXT + ' (grep/Read it) — Übersicht, Arc42, Projektbeschreibung, Reflexion, Eigenständigkeitserklärung. This is literally what Moodle receives.',
   '  - The examiner also has the GitHub repo, linked from the Übersicht. The bundle text at ' + BUNDLE_TXT + ' inlines those repo-only artifacts (full use-cases, design docs, all ADRs, Block-Nachbereitungen) as a SUPERSET. Content found ONLY in the bundle (not in ' + UPLOAD_TXT + ') is reachable by the real examiner only by following a repo link — treat it as weaker/secondary evidence and say so when a score leans on it.',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -540,3 +540,30 @@ bruno/
 - Keep requests in sync with endpoints — when adding/changing an API endpoint, update or add the corresponding Bruno request
 - Include example request bodies with realistic test data
 - Add assertions in Bruno where useful (status code, response shape)
+
+## Search discipline — runs on shared agent-dev, do NOT OOM the host
+
+This repo is worked on from the agent-dev LXC (201), which shares `cirrus-pve`'s
+RAM with ~11 other guests. CT 201 has a 12 GB cgroup cap, but **filling that cap
+still swap-thrashes the whole node** — constant cgroup reclaim saturates host IO,
+drives load into the triple digits, and wedges SSH + `mosh-server` for every
+guest. On 2026-06-27 an unbounded `ugrep` in the `examiner-sim` slot hit ~9.8 GB
+RSS and took the node down twice (knocking out authentik, vaultwarden, git, …).
+So when searching repo / presentation / demo content:
+
+- Use `rg` (ripgrep), never bare `ugrep` / `grep -r`. rg respects `.gitignore`,
+  skips binaries, and is memory-bounded by default.
+- NEVER use open-ended `-o -E .{0,N}(…).{0,N}` context windows — they buffer
+  enormous match output. Use a small fixed context (`-C2`) instead.
+- Scope the path to what you need (`vault/`, `docs/`, `nachbereitung/`), never
+  the worktree root, `$HOME`, or `/tmp/wt-*`.
+- Exclude heavy trees: `.git`, `node_modules`, `.venv`, `.dotnet`, `bin/`,
+  `obj/`, `upload/`, and generated PDFs.
+- Cap it: add `--max-filesize=2M` and `-m <count>`.
+- Do not run a build (`just package-submission`, dotnet) and a broad search at
+  the same time — they compound memory pressure.
+
+Replacement for the search that caused the outage:
+
+    rg -n -C2 -g'!{node_modules,.venv,.dotnet,upload,bin,obj}' \
+       -e 'demo|reset|15\.?min|banner|wiped|sandbox' vault docs

--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -3,3 +3,24 @@
 - [ ] How to manual test the semantic search (postgres vectorized stuff)?
 - [x] Test projects for Vikunja: Quotes, Movies, Ausflugziele — covered by `just test-services` (see `tests/FlowHub.Skills.IntegrationTests/VikunjaCatalogLiveTests.cs`)
 - [ ] Test paperless-ngx (flowhub-test-services)
+
+## Path to 100/100 — examiner-sim review 2026-06-27 (currently 96/100)
+
+Source: `nachbereitung/examiner-sim/report-2026-06-27T1201.md`. All recoverable points
+come from moving repo-only content into the rendered submission PDFs — no new engineering.
+
+- [ ] **+3 pts — Interaction/interface diagram in Arc42** (Entwurf · Mehrere Perspektiven, 4→7).
+  Add a dedicated interaction/interface-contract diagram (OpenAPI/contract view or a
+  component-interface diagram) *inline in the Arc42 PDF*. Today the contract is prose-only in
+  the rendered submission; the OpenAPI/Scalar surface is repo-only. **Highest-leverage gap.**
+- [ ] **+1 pt — Full use-case structure inline in Arc42** (Spezifikation · Use-Cases, 4→5).
+  Render the full UC structure (Actor / Trigger / Precondition / Flow / Postcondition / Error /
+  Akzeptanzkriterien) for ≥3–5 core functions *in the Arc42 PDF*, not only via the
+  `docs/spec/use-cases.md` repo link.
+- [ ] **Submission-blocking (0 pts, but protects the earned grade):**
+  - [ ] Fix the stale convenience bundle: repair the `just pdf-submission-bundle` manifest path
+    typo `vault/Blöcke/04 Persitence/04 Persistence - c) Nachbereitung.md`
+    (`Persitence` → `Persistence`) so the 261-page bundle rebuilds (currently exit 1, stale).
+  - [ ] Sign `04_Eigenstaendigkeitserklaerung.pdf` before uploading (rendered artifact is unsigned).
+
+Total recoverable on the rendered artifacts: **+4 → 100/100**.

--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -13,6 +13,9 @@ come from moving repo-only content into the rendered submission PDFs — no new 
   Add a dedicated interaction/interface-contract diagram (OpenAPI/contract view or a
   component-interface diagram) *inline in the Arc42 PDF*. Today the contract is prose-only in
   the rendered submission; the OpenAPI/Scalar surface is repo-only. **Highest-leverage gap.**
+  - [ ] Diagram quality: when drawing blocks-and-lines, **label every arrow** (relationship /
+    protocol / data direction) — unlabeled connectors are a recurring arc42 review deduction.
+    Applies to *all* submission diagrams, not just the new interaction view.
 - [ ] **+1 pt — Full use-case structure inline in Arc42** (Spezifikation · Use-Cases, 4→5).
   Render the full UC structure (Actor / Trigger / Precondition / Flow / Postcondition / Error /
   Akzeptanzkriterien) for ≥3–5 core functions *in the Arc42 PDF*, not only via the

--- a/nachbereitung/examiner-sim/report-2026-06-27T1201.md
+++ b/nachbereitung/examiner-sim/report-2026-06-27T1201.md
@@ -1,0 +1,169 @@
+# FlowHub CAS-AISE — Examiner Grade Sheet (focus = balanced)
+
+**Run metadata**
+
+| Field | Value |
+|---|---|
+| Date | 2026-06-27 |
+| Commit | `6baa77b` |
+| Demo URL | https://demo.flowhub.freaxnx01.ch |
+| Stamp | 2026-06-27T1201 |
+| Upload set (PRIMARY graded artifacts) | 5 PDFs, 97 pages: `00_Uebersicht` (9p), `01_Arc42` (29p), `02_Projektbeschreibung` (36p), `03_Reflexion` (21p), `04_Eigenstaendigkeitserklaerung` (2p) |
+| Convenience bundle | `SUBMISSION-bundle.pdf`, 261 pages — **STALE** (mtime 2026-06-19 19:58; rebuild failed) |
+| Max achievable | **100** (rubric update June 2026: the framework-concepts item is framework-neutral and fully in scope for .NET; **no item is excluded**) |
+
+> **Build risk note.** The PRIMARY upload set (`upload/0*.pdf`) was fully rebuilt this run (mtime 2026-06-27 12:02, matches `date +%F`) and extracted cleanly via `just package-submission` (exit 0). However `just pdf-submission-bundle` **FAILED (exit 1)** on a missing-file reference (`vault/Blöcke/04 Persitence/04 Persistence - c) Nachbereitung.md`, note the typo `Persitence` in the directory name), so the 261-page convenience bundle is stale and was extracted from the 2026-06-19 PDF as graceful-degradation fallback. The bundle is the repo-only safety net and is **not** part of the Moodle upload, so the graded artifacts are unaffected — but this directly reinforces the grading principle below: **content reachable only via the repo/bundle is treated as secondary**, because it is not what the examiner receives in the Moodle upload. The Eigenständigkeitserklärung (04) is unsigned in the rendered artifact ("Sign 04 before uploading.") — expected for the build, must be signed before submission.
+
+---
+
+## 2. Overall result
+
+### FINAL score: **96 / 100**
+
+**Grade band: outstanding (top of the scale; distinction-level).**
+
+This is an exceptionally strong, evidence-anchored Projektarbeit. The submission combines a complete SMART-specified requirements set, a professional arc42 design backed by nine Accepted ADRs, a genuinely well-engineered .NET 10 modular monolith with a 698-commit incremental history and ~458 tests, and a standout AI-and-architecture story that is **confirmed first-hand by a live, production-deployed demo** doing real LLM classification, title enrichment, and downstream writes to sandboxed Vikunja/Wallabag instances behind TLS with rate limiting and RFC 7807 error handling. The only material deductions are a single point in Spezifikation (the full use-case structure with flows/acceptance-criteria is present only in the repo/bundle, while the rendered Arc42 PDF carries the UC set as an overview table) and the inherent build risk that the convenience bundle is stale. No grade inflation was found; where the first examiner was too harsh (Programmierung item 8), the skeptic's correction was applied.
+
+---
+
+## 3. Per-bucket result
+
+| Bucket | First-pass | Final | Max |
+|---|---:|---:|---:|
+| Spezifikation | 15 | **14** | 15 |
+| Entwurf | 14 | **14** | 17 |
+| Programmierung | 21 | **22** | 22 |
+| Validierung | 16 | **16** | 16 |
+| KI und Architektur | 30 | **30** | 30 |
+| **Total** | **96** | **96** | **100** |
+
+---
+
+## 4. Per-item detail
+
+### Spezifikation (14 / 15)
+
+| Item | Scale | First | Final | Justification | Key evidence | Gap to next level |
+|---|---|---:|---:|---|---|---|
+| Wichtigste Use-Cases & fachliche Anforderungen | 0/1/3/5 | 5 | **4** | Actors + stakeholders (role + expectation) are complete in the PDF and far more than 3–5 core functions are named, but the **full** UC structure (Actor/Trigger/Precondition/Flow/Postcondition/Error/Akzeptanzkriterien) lives only in the repo superset; the rendered Arc42 PDF carries UC-01..UC-18 as a 4-column overview table. The L5 anchor's "ausformulierte Abläufe + prüfende AK" is therefore bundle/repo-only → L5−1. | `upload.txt` Arc42 §1.4 Tab. 3 UC-01..18 (overview, Z. 534-617); §1.3 Tab. 2 Stakeholder (Z. 510-531); `docs/spec/use-cases.md` full structure (repo) | Inline the full UC structure (flows + acceptance criteria) for ≥3–5 core functions **in the Arc42 PDF**, not only via repo link. |
+| Qualitätsanforderungen (NfA) nach SMART | 0/1/3/5 | 5 | **5** | Tab. 5 gives a measurable target **and** a concrete measurement method for every NfA (NfA-01..05, D1-D3, O1, P1-P2) directly in the PDF (p95<100ms via OTel/Testcontainers; <200MB via GHCR layers; /health/live<30s via Compose healthcheck). `nfa.md` adds full S·M·A·R·T decomposition (repo). | `upload.txt` Arc42 §10 Tab. 5 (Z. 1809-1896); `docs/spec/nfa.md` | — (top). Cosmetic: explicit S/M/A/R/T labels + ADR refs in the NfA table itself are repo-only; not required by the anchor. |
+| Grundsätzliche Vision | 0/1/3/5 | 5 | **5** | Problem (verstreute Schnipsel), target group/persona "Andreas", real need ("Capture without friction", 5→1 step), explicit boundary ("Was FlowHub nicht ist"), and one AI-benefit sentence per core function — all in the PDFs, twice. | `upload.txt` Projektbeschreibung §1/§3/§10; Arc42 §1 | — (top). |
+
+### Entwurf (14 / 17)
+
+| Item | Scale | First | Final | Justification | Key evidence | Gap to next level |
+|---|---|---:|---:|---|---|---|
+| Lösungsansatz & Architektur (bildlich + textuell) | 0/1/4/7 | 7 | **7** | Context view (Abb. 1, C4 L1 + relationship table), building-block view (Abb. 2, modular monolith + module-responsibility table), style explicitly named (modular monolith, hexagonal) and ADR-justified; nine ADRs all Accepted (far exceeds "≥3"). Red thread problem→solution→reflection intact, all rendered in the PDF. | `upload.txt` Arc42 §3.2, §5.1, §4 (ADR 0001-0007), §9 (nine ADRs) | — (top). |
+| Mehrere Perspektiven (Struktur/Verhalten/Interaktion) | 0/1/4/7 | 4 | **4** | Structure (Abb. 2 + Ports&Adapter) and Behaviour (Abb. 4 state diagram + five sequence diagrams) are each fully diagram+text in the PDF. The third, distinct **Interaction** perspective is **prose-only** in the rendered submission (port signatures, RFC 9457 ProblemDetails, /api/v1); the real OpenAPI/Scalar contract surface appears only in the bundle/repo. Sequence diagrams cannot be double-counted as both behaviour and interaction → L7 diagram anchor for the 3rd perspective not met → L4. | `upload.txt` Arc42 §5.2/§5.4, §6.1-6.6, §8.7; `bundle.txt` /scalar, `api-surface.md` (repo) | Add a dedicated **interaction/interface diagram** (OpenAPI/contract or component-interface view) inline in the Arc42 PDF. **Highest-leverage gap: +3 points.** |
+| DB-Model spezifiziert | 0/1/2/3 | 3 | **3** | ER diagram (Abb. 3) with all entities, PK/FK, column types and named relationships; pgvector + HNSW-cosine documented (no separate vector DB, ADR 0006); migration strategy in the PDF (Init-Container/efbundle), 14 real EF migration files in the repo. | `upload.txt` Arc42 §5.6, §8.2, §7.1; `source/FlowHub.Persistence/Migrations/` | — (top). |
+
+### Programmierung (22 / 22)
+
+| Item | Scale | First | Final | Justification | Key evidence | Gap to next level |
+|---|---|---:|---:|---|---|---|
+| Code lesbar, dokumentiert, nach Schichten/Modulen | 0/1/4/7 | 7 | **7** | Six clearly-bounded projects; `FlowHub.Core` verifiably pure (zero package/project refs); intent-revealing names; XML docs at non-trivial spots; no presentation/business/data mixing; module boundaries consistent with the design. | `source/FlowHub.Core/*.csproj`; `AiClassifier.cs`; `CaptureWriteEndpoints.cs`; `upload.txt` §5 | — (top). |
+| Framework- & moderne App-Konzepte (DI/REST/Config/Fehler) | 0/3/7/10 | 7 | **10** | **Skeptic correction applied.** All four named concepts are idiomatic in the primary text: DI via per-module `IServiceCollection` extensions; REST via Minimal API + TypedResults + RFC 9457 ProblemDetails; Options/12-Factor config with `ValidateOnStart`; deterministic AiClassifier→KeywordClassifier fallback. The two L7-blockers fail verification: tracing is **actually wired** (as-built §8.7/matrix + `Program.cs:46-65` `WithTracing()` + `TagAllowListProcessor` + always-on console + conditional OTLP; the lone "geplant" line is stale/self-contradicted), and the AOT caveat is **bundle-only** (absent from `upload.txt`) and not one of the four rubric concepts → "durchgehend idiomatisch" met → 10. | `upload.txt` §8.7 (Z. 1602, 1912-1916); `source/FlowHub.Web/Program.cs`; Übersicht concept list | — (top). |
+| Erkenntnisse aus der Programmierung dokumentiert | 0/1/2/3 | 3 | **3** | Five concrete, project-anchored findings in the PRIMARY text tied to named code (embedding-on-submit caught by /ultrareview as p95 violation; Pgvector/MassTransit.Testing assumption corrections; compose/.editorconfig smoke defects), explicitly calling out accepted/corrected AI suggestions. | `upload.txt` Projektbeschreibung "Wiederkehrende Fehlerquellen" (Z. 3488-3515); `docs/insights/block-5.md` | — (top). |
+| Source-Code im Git-Repo verfügbar | 0/2 | 2 | **2** | Public repo URL in Übersicht + Arc42 + Projektbeschreibung; full tree present; healthy 698-commit incremental history (2026-01-29→2026-06-27, ~518 conventional-commit-typed, no deadline squash dump). | `upload.txt` Z. 4-5, 285; `git log` | — (top). |
+
+### Validierung (16 / 16)
+
+| Item | Scale | First | Final | Justification | Key evidence | Gap to next level |
+|---|---|---:|---:|---|---|---|
+| Abnahmekriterien definiert | 0/1/3/5 | 5 | **5** | 50 testable ACs, one+ per core function, each with verifying test and (where applicable) NfA linkage — stated and sampled in the PRIMARY Arc42 §8.9; full 50-row catalogue in repo. | `upload.txt` §8.9 (Z. 1675-1727); `docs/spec/acceptance-criteria.md` | — (top). |
+| Teststrategie & Technologien spezifiziert | 0/1/3/5 | 5 | **5** | Stages + tools named and justified (bUnit/NSubstitute/FluentAssertions/xUnit/Testcontainers/Playwright; "kein In-Memory-Provider-Drift"); KI parts handled deterministically (5 fallback-path tests, EventId 3010, schema validation). | `upload.txt` §8.8 (Z. 1654-1672); `testing-strategy.md`; `ci.yml` | — (top). |
+| Unit-Tests programmiert | 0/1/3 | 3 | **3** | ~458 [Fact]/[Theory] across 119 files; 294 offline tests green/0/0 in CI; covers core logic incl. error/fault paths (fallback, validation rejections, 400/404/409 ProblemDetails). | repo scan; `testing-strategy.md` (run 2026-06-16); `upload.txt` §8.8; `ci.yml` | — (top). |
+| Test-Ergebnisse dokumentiert | 0/1/3 | 3 | **3** | Traceable pipeline output cited (CI Run #27510188698, 2026-06-14, 294/0 over 6 projects, coverage artifact) AND interpreted (count-reconciliation table; smoke run surfacing three real defects). | `upload.txt` Übersicht Z. 362-363; `testing-strategy.md`; `block-5.md` | — (top). |
+
+### KI und Architektur (30 / 30)
+
+| Item | Scale | First | Final | Justification | Key evidence | Gap to next level |
+|---|---|---:|---:|---|---|---|
+| KI-Werkzeuge verwendet & Nutzung beschrieben | 0/1/7/12 | 12 | **12** | AI usage described per phase (Generierung/Review/Refactoring/Recherche) in the primary upload; Hilfsmittelverzeichnis maps every tool to purpose + affected locations and separates submission-text vs runtime tools; full Selbständigkeitserklärung; "every part explainable" backed by auditable correction-stories. | `upload.txt` Projektbeschreibung §9; Eigenständigkeitserklärung §1/§2; Reflexion §1 | — (top). |
+| Intelligente & flexible Services gebaut | 0/2/6 | 6 | **6** | Two substantial AI roles (LLM classification/enrichment + pgvector semantic search), real guardrails (deterministic fallback, schema-validated MatchedSkill, token/temp/timeout caps) and human-in-the-loop (Orphan/Unhandled inbox + retry). **Confirmed first-hand on the live demo**: real LLM round-trip (OpenRouter/gemma, token counts, ~4.7s), title enrichment, downstream writes to Vikunja (extRef 68) and Wallabag (extRef 21), graceful Orphan fallback. | `upload.txt` Arc42 §8.1; `source/FlowHub.AI/*`; **live demo round-trip** | — (top). |
+| Klar abgegrenzte Module/Sub-Systeme & als Container lauffähig | 0/1/3/5 | 5 | **5** | Module boundaries documented (Bausteinsicht L1, cross-module via Ports, ADR 0002); style named "Modular Monolith" and justified with reversible scaling path; runnable six-service Compose stack (verified `docker-compose.yml`). **Live demo confirms** production deployment behind Traefik/TLS with a status page and per-integration health. Per June-2026 rubric, modular monolith as a container qualifies fully. | `upload.txt` Arc42 §5, §7.1; verified `docker-compose.yml`; **live demo** | — (top). |
+| Erfahrungen mit KI-Tools als Fazit reflektiert | 0/1/4/7 | 7 | **7** | Dedicated Reflexion PDF lists exactly three concrete, justified, evidenced Veto-Entscheidungen (architecture style/transport; system-invariants vs locally-correct AI code; scope/port-contracts) with explicit Übertrag to future practice; substantial surrounding chapter (hypothesis test, future-process changes). | `upload.txt` Reflexion §8 (Z. 4261-4300), §6, §7 | — (top). |
+
+---
+
+## 5. Live demo walkthrough
+
+**Reachable:** yes. `GET /` → 200 (70 KB Blazor/MudBlazor SPA); `GET /health/live` → 200 "Healthy".
+
+**What was submitted & how it was classified (full AI round-trip confirmed, not stubbed):**
+- Bare arXiv URL → **Wallabag** (read-later), AI-enriched title "Attention Is All You Need Paper", `externalRef 21`, `finalStage=Completed`. Trace: `kind=Ai provider=OpenRouter model=google/gemma-4-31b-it:free promptTokens=312 completionTokens=76`, latency ~4.7s.
+- `todo: buy milk` → **Vikunja**, title "buy milk", `externalRef 68`, project Inbox.
+- Capture id `f91f261c-aff2-4771-8c87-3f3cda766800`.
+- **Non-determinism caveat:** the exact examiner phrasing ("save <url> to read later") went to **Orphan** on first attempt ("no skill matched"), then on retry reached **Completed→Wallabag**. The free-tier gemma model occasionally returns no-match for identical input. Film tip and "read this later: bbc.com" → Orphan (no Movies/news skill wired → correct fallback, not a defect).
+
+**Rate limiting:** active per-IP token-bucket, differentiated by route. Home GET burst (40): 21x 200 then 19x 429. Write path POST /api/v1/captures burst (40): only 2x 201 then 38x 429 (tighter, protecting downstream demo instances). `Retry-After: 4` advertised. Note: a 25-GET burst returned all 200 (window had refilled), so the limit is not visible at exactly the suggested 25-GET probe — it is genuinely present at higher burst and on writes.
+
+**Embeddings / semantic search:** deliberately disabled and honestly surfaced — `GET /api/v1/captures/search?q=paper` → **HTTP 503** with RFC 7807 `application/problem+json` (type URL → `docs/problems/validation.md`, clear detail "Set Embeddings__ApiKey to enable", traceId).
+
+**Reset posture:** explicit and transparent. UI banner: "Public demo … Data resets every 15 min; semantic search is off." Live service chips (Vikunja, Zitate, Wallabag, Paperless-ngx), lock chip, WALKTHROUGH/STATUS/SOURCE links, Skill health + Integration health (all healthy). 15-min self-reset stated but not directly observed in-session.
+
+**Screenshots:**
+- `./nachbereitung/examiner-sim/screenshots/home-2026-06-27T1201.png`
+- `./nachbereitung/examiner-sim/screenshots/captures-list-2026-06-27T1201.png`
+
+**Issues observed:**
+1. **Classifier non-determinism** — identical input produced Orphan then Completed on retry; a free-tier model makes classification flaky and slow (~4–5s). A single-shot examiner could see an Orphan and wrongly conclude routing is broken. Mitigation: banner note "demo uses a free model; retry if a capture orphans" or a more deterministic demo profile.
+2. **Rate limit invisible at the suggested 25-GET home probe** (window refilled) — only visible at ~40 GETs / on writes. Present, just not at that exact probe.
+3. **Wallabag dedupes by URL** — both the bare-URL and retried captures returned `externalRef 21` (same entry reused). Reasonable, but an examiner might expect a distinct ref per capture.
+4. **Paperless not exercised live** (needs multipart PDF/image upload, not a JSON POST). Evidenced indirectly via an "unhandled" scanned-receipt row + healthy integration status. A complete pass should upload a document to prove the third integration end-to-end.
+5. **Terse Orphan failureReason** ("no skill matched during classification"), no per-skill scores — harder for an examiner to judge *why* the AI declined to route.
+
+---
+
+## 6. Top gaps ranked by point-leverage
+
+1. **Interaction/interface diagram in Arc42 (Entwurf item 2): +3 points, 4→7.** The single biggest lever. Add a dedicated interaction/interface-contract diagram (OpenAPI/contract view or component-interface diagram) **inline in the Arc42 PDF**; today the contract is prose-only in the rendered submission and the OpenAPI/Scalar surface is repo-only.
+2. **Full use-case structure inline in the PDF (Spezifikation item 1): +1 point, 4→5.** Render the full UC structure (Actor/Trigger/Precondition/Flow/Postcondition/Error/AK) for ≥3–5 core functions **in the Arc42 PDF**, not only via the `docs/spec/use-cases.md` repo link.
+3. **(No points, but submission-blocking risk) Fix the stale bundle build + sign the Eigenständigkeitserklärung.** Repair the `pdf-submission-bundle` manifest path (`vault/Blöcke/04 Persitence/…` typo) so the convenience bundle rebuilds, and sign `04_Eigenstaendigkeitserklaerung.pdf` before upload. These don't move the score but protect the grade you've already earned.
+
+> Total recoverable on the rendered artifacts: **+4 points → 100/100**, both by moving repo-only content into the primary PDFs (no new engineering required).
+
+---
+
+## 7. Defense questions (sharpest, grouped by bucket)
+
+**Spezifikation**
+1. Your Arc42 PDF shows UC-01..UC-18 only as an overview table — walk me through the full flow and acceptance criteria of one non-trivial use case (e.g. AI classification with fallback) without referring to the repo.
+2. NfA-P1/P2 are marked "Ziel/offen". What is the abnahme definition for each, and why were they deferred rather than dropped?
+
+**Entwurf**
+3. You claim three perspectives. Where is the **interaction** perspective expressed as a diagram in the submitted PDF, as opposed to the structure and behaviour diagrams? How do the sequence diagrams differ from an interaction/contract view?
+4. Justify storing embeddings as a pgvector column in the same PostgreSQL (ADR 0006) versus a dedicated vector store — what are the failure and scaling trade-offs?
+
+**Programmierung**
+5. `FlowHub.Core` has zero outbound references. Show how a Persistence concern (e.g. an EF query) reaches the domain without violating the dependency direction.
+6. Tracing: the matrix once read "geplant". Demonstrate that tracing is actually wired in `Program.cs` and explain what `TagAllowListProcessor` does and why.
+7. The embedding-on-submit case was a locally-correct AI suggestion you rejected. Why did it violate NfA-09, and how does the consumer-based design fix it?
+
+**Validierung**
+8. Different documents quote 31/99/171/223/294 tests. Which is canonical, and what does each number represent?
+9. How exactly do you test the non-deterministic AI path deterministically? What does the EventId 3010 fallback guarantee, and what could still slip through?
+
+**KI und Architektur**
+10. Your demo showed identical input going to Orphan then Completed on retry. Is that a guardrail working as designed or a reliability defect — and how would you make the production classification deterministic?
+11. You list exactly three Veto-Entscheidungen. For the system-invariants veto, what concretely would have gone wrong in production had you accepted the AI's code, and how is the boundary enforced now?
+12. The demo runs a modular monolith in one host process. At what concrete load/operational signal would you split a module out, and which one first — and what makes that reversible per ADR 0002?
+
+---
+
+## 8. Skeptic disputes & resolution
+
+| Bucket | Item | Examiner | Skeptic | Final | Resolution |
+|---|---|---:|---:|---:|---|
+| Spezifikation | Use-Cases & fachliche Anforderungen | 5 | 4 | **4** | **Adopted skeptic.** Full UC structure is bundle/repo-only; the rendered PDF carries only the overview table, so the L5 "ausformulierte Abläufe + AK" anchor is not PDF-present. -1. |
+| Spezifikation | NfA SMART | 5 | 5 | **5** | Upheld. Target + measurement per NfA is PDF-present. |
+| Spezifikation | Vision | 5 | 5 | **5** | Upheld. All L5 anchors PDF-present. |
+| Entwurf | Lösungsansatz & Architektur | 7 | 7 | **7** | Upheld; verified in `upload.txt`, not just bundle. |
+| Entwurf | Mehrere Perspektiven | 4 | 4 | **4** | Upheld both directions; interaction diagram is the missing third perspective. |
+| Entwurf | DB-Model | 3 | 3 | **3** | Upheld; ER diagram + strategy PDF-present, 14 migration files in repo. |
+| Programmierung | Framework-/App-Konzepte | 7 | 10 | **10** | **Adopted skeptic.** Both L7-blockers fail: tracing is wired (`Program.cs` + as-built text); AOT caveat is bundle-only and not a rubric concept. First examiner was too harsh. +3. |
+| Programmierung | other 3 items | 7/3/2 | = | **=** | Upheld. |
+| Validierung | all 4 items | 5/5/3/3 | = | **=** | Upheld; all L-anchors PDF-present, repo artifacts confirmatory. |
+| KI und Architektur | all 4 items | 12/6/5/7 | = | **=** | Upheld; every substance in primary upload, source + `docker-compose.yml` verify, **live demo reinforces** items 2 & 3. |
+
+**Net effect of disputes:** -1 (Spezifikation) and +1 (Programmierung) cancel out at the total level → **96/100** both first-pass and final, but the bucket distribution shifts (Spezifikation 14, Programmierung 22).


### PR DESCRIPTION
Doc-only. Saves the examiner-sim 96/100 grade report, records the +4-point path-to-100 actions in docs/project/TODO.md incl. the arrow-labeling note, and adds the CLAUDE.md search-discipline guardrail after the 2026-06-27 agent-dev OOM incident.