### PR TITLE
docs: fix stale ~/projects path to ~/repos in vault/CLAUDE.md

### DIFF
--- a/vault/CLAUDE.md
+++ b/vault/CLAUDE.md
@@ -56,7 +56,7 @@ Do NOT add frontmatter to pages that are only being read, not modified.
 After creating or editing vault pages, commit and push from the FlowHub repo root:
 
 ```bash
-cd /home/freax/projects/repos/github/freaxnx01/public/FlowHub-CAS-AISE
+cd /home/freax/repos/github/freaxnx01/public/FlowHub-CAS-AISE
 git add vault/
 git commit -m "docs(vault/<scope>): <description>"
 git push


### PR DESCRIPTION
One-line doc fix: the git clone tree moved `~/projects/repos` → `~/repos` (2026-06-03), so `vault/CLAUDE.md`'s `cd` example pointed at a dead path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159qHnUtXSWVX5677DQfWTx