### PR TITLE
docs(vault): file the tiered model-routing recommendation

### DIFF
--- a/vault/Projektarbeit/Model-Routing.md
+++ b/vault/Projektarbeit/Model-Routing.md
@@ -1,0 +1,20 @@
+# Model Routing for the AI-Assisted Dev Workflow
+
+External recommendation saved for reference — a **tiered routing** approach via
+**OpenCode** (handles 75+ providers cleanly): pick the model per workflow phase
+instead of one model for everything.
+
+| Phase | Model | Why |
+|---|---|---|
+| Brainstorm + spec + plan | **Opus 4.7 (Max)** | Already paying flat-rate — use the reasoning |
+| Implementation (default) | **Qwen3-Coder-Next** via OpenRouter | 256K context fits big plans + code; fast; Apache 2.0 |
+| Implementation (EU data needed, work-adjacent) | **Devstral 2** via Mistral | Have credits; EU-hosted |
+| Quick fixes / small edits | **DeepSeek V3.2** via OpenRouter | Cheapest competent option |
+
+**Principle:** reasoning-heavy phases (brainstorm / spec / plan) → top-tier
+model; bulk implementation → strong open-weights coder with large context;
+trivial edits → cheapest competent model. OpenCode does the provider routing.
+
+> Source: chat recommendation (screenshot), saved 2026-06-21. Conceptually related
+> to the FlowHub roadmap items *Additional AI Providers* and *LiteLLM Proxy* — but
+> this is about the **dev workflow**, not the FlowHub product's runtime providers.


### PR DESCRIPTION
Rescues the one piece of unique content from the abandoned `salvage/model-routing-orphans` branch before that branch is deleted.

`vault/Projektarbeit/Model-Routing.md` — a reference note on tiered, per-phase model routing for the dev workflow (top-tier model for brainstorm/spec/plan, strong open-weights coder for bulk implementation, cheapest competent model for trivial edits). This file existed nowhere on main; the branch's other changes (`justfile`, `docker-compose`) were stale and already superseded.

Docs/vault only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)