### PR TITLE
docs(tests): align offline test count 294 -> 540

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Requires .NET 10 SDK (`global.json` pins the version). The `justfile` exposes ev
 
 ```bash
 just build       # build the full solution (warnings as errors)
-just test        # run the default suite — 294 tests (excludes live AI / BetaSmoke / E2E)
+just test        # run the default suite — 540 tests (excludes live AI / BetaSmoke / E2E)
 just run         # run FlowHub.Web on http://localhost:5070
 just watch       # same, with hot reload
 ```

--- a/docs/architektur/FlowHub_Arc42_v2.md
+++ b/docs/architektur/FlowHub_Arc42_v2.md
@@ -966,7 +966,7 @@ Blazor-Komponenten, NSubstitute für Mocks, FluentAssertions, xUnit;
 **Testcontainers gegen echtes PostgreSQL** für Repository-Tests (kein
 In-Memory-Provider-Drift); Playwright für E2E; Live-KI-Tests sind trait-gegatet
 (`[Trait("Category","AI")]`) und aus der Default-Suite ausgeschlossen.
-Abgabestand: **294 Offline-Tests grün, 0 Fehler, 0 übersprungen**. Volltext und
+Abgabestand: **540 Offline-Tests grün, 0 Fehler, 0 übersprungen**. Volltext und
 Reconciliation-Tabelle in `docs/spec/testing-strategy.md`.
 
 **Test der KI-Anteile (Guardrails, nicht nur Trait-Gating).** Über das

--- a/docs/project/submission-notes.md
+++ b/docs/project/submission-notes.md
@@ -66,7 +66,7 @@ Walk this list top-to-bottom. Each step is gated by the previous.
       since the June-2026 update), gaps consciously accepted are documented
 - [ ] **Remaining CAS todos cleared**: `cas-aise-todo-list full` — no open
       submission-gating `- [ ]` items
-- [ ] `just test` green: **294 / 294** across the 6 offline test projects
+- [ ] `just test` green: **540 / 540** across the 6 offline test projects
 - [ ] `just build` clean with warnings-as-errors enforced
 - [ ] `git status` clean on `main`; no uncommitted/untracked files
 - [ ] Last CI run on `main` is green: `gh run list --workflow=ci.yml --branch=main --limit 1`

--- a/docs/spec/testing-strategy.md
+++ b/docs/spec/testing-strategy.md
@@ -44,27 +44,29 @@ graph TD
 > | This section / Block 3 | 3 | `Category!=AI` (default suite) | 99 |
 > | Block 4 Nachbereitung (`docs/insights/block-4.md`) | 4 | `FullyQualifiedName!~E2ETests` (incl. AI + integration) | 223 (6 skipped) |
 > | Block 5 Nachbereitung (`docs/insights/block-5.md`) | 5 | `Category!=AI&!=BetaSmoke&!=E2E` (offline default suite) | 171 (0 skipped) |
-> | **Submission build (this doc)** | 5 | `Category!=AI&!=BetaSmoke&!=E2E` (offline default suite) | **294 (0 skipped)** |
+> | **Submission build (this doc)** | 5 | `Category!=AI&!=BetaSmoke&!=E2E` (offline default suite) | **540 (0 skipped)** |
 >
-> **Canonical figure at submission:** **294 offline tests green, 0 failed, 0
-> skipped** (the default CI suite), and the suite additionally passes the AI +
-> live-service integration tests when their categories are enabled (E2E excluded).
-> The lower historical numbers are earlier per-block snapshots, retained in the
-> Nachbereitungen as a progress record.
+> **Canonical figure at submission:** **540 offline tests green, 0 failed, 0
+> skipped** (the default CI suite — the same `Category!=AI&!=BetaSmoke&!=E2E`
+> filter as the latest `main` CI run #28324532702), and the suite additionally
+> passes the AI + live-service integration tests when their categories are enabled
+> (E2E excluded). The lower historical numbers (incl. the earlier 294-test
+> snapshot) are earlier per-block snapshots, retained in the Nachbereitungen as a
+> progress record.
 
 ### Verified test run (rendered evidence)
 
-Output of `just test` (`dotnet test FlowHub.slnx --filter "Category!=AI&Category!=BetaSmoke&Category!=E2E"`), run **2026-06-16**:
+Output of `just test` (`dotnet test FlowHub.slnx --filter "Category!=AI&Category!=BetaSmoke&Category!=E2E"`), run **2026-06-28**:
 
 | Test project | Passed | Failed | Skipped |
 |---|---:|---:|---:|
-| FlowHub.Core.Tests | 6 | 0 | 0 |
+| FlowHub.Core.Tests | 59 | 0 | 0 |
 | FlowHub.Skills.ContractTests | 17 | 0 | 0 |
-| FlowHub.Api.IntegrationTests | 21 | 0 | 0 |
-| FlowHub.Skills.Tests | 31 | 0 | 0 |
-| FlowHub.Web.ComponentTests (bUnit) | 181 | 0 | 0 |
-| FlowHub.Persistence.Tests (Testcontainers, real PostgreSQL) | 38 | 0 | 0 |
-| **Total** | **294** | **0** | **0** |
+| FlowHub.Api.IntegrationTests | 23 | 0 | 0 |
+| FlowHub.Skills.Tests | 54 | 0 | 0 |
+| FlowHub.Web.ComponentTests (bUnit) | 282 | 0 | 0 |
+| FlowHub.Persistence.Tests (Testcontainers, real PostgreSQL) | 105 | 0 | 0 |
+| **Total** | **540** | **0** | **0** |
 
 `Passed! - Failed: 0, …` for every assembly; the persistence suite runs against a
 real PostgreSQL container via Testcontainers (not InMemory). AI- and E2E-tagged
@@ -198,7 +200,7 @@ public sealed class AnthropicHaikuLiveTests
 #### Trait filtering strategy
 
 Tests use `[Trait("Category", "AI")]` to partition:
-- **Default suite** (`Category!=AI&Category!=BetaSmoke&Category!=E2E`): 294 tests, runs every build, no external dependencies
+- **Default suite** (`Category!=AI&Category!=BetaSmoke&Category!=E2E`): 540 tests, runs every build, no external dependencies
 - **Live AI suite** (`Category=AI`): 4 tests, runs on-demand, requires real API credentials
 
 ## Test Naming Convention


### PR DESCRIPTION
Resolves the examiner-sim defense-hardening gap #1 (test-count inconsistency).

**Problem:** SUBMISSION.md cited **540** (latest main CI run #28324532702) while testing-strategy.md / Arc42 §8.8 / README / submission-notes still showed **294**. Both use the identical offline filter (`Category!=AI&!=BetaSmoke&!=E2E`) — so 294 was simply a stale snapshot (2026-06-16); the suite grew to 540.

**Verified:** re-ran `just test` on main @ 479e55e (2026-06-28), 540 passed / 0 failed / 0 skipped. Per-project: Core 59 · ContractTests 17 · Api.Integration 23 · Skills 54 · Web.Component(bUnit) 282 · Persistence(Testcontainers) 105 = **540**. Updated the testing-strategy table + canonical figure + date, Arc42 §8.8, README, submission-notes.

Note: rendered PDFs regenerate from this markdown via `just package-submission` at submission time.

(Defense gap #3 — classifier model id `google/gemma-4-31b-it:free` — needs no change: it is a real, current OpenRouter free model; the examiner flag was stale-knowledge.)