### PR TITLE
docs(examiner-sim): add 2026-06-28 balanced grade sheet (98/100)

### DIFF
--- a/nachbereitung/examiner-sim/report-2026-06-28T1907.md
+++ b/nachbereitung/examiner-sim/report-2026-06-28T1907.md
@@ -1,0 +1,146 @@
+# FlowHub CAS-AISE — Examiner Grade Sheet (focus = balanced)
+
+| Run metadata | Value |
+|---|---|
+| Date | 2026-06-28 |
+| Commit | 479e55e |
+| Demo URL | https://demo.flowhub.freaxnx01.ch |
+| Upload bundle | 5 numbered PDFs (00 Übersicht 9p · 01 Arc42 38p · 02 Projektbeschreibung 37p · 03 Reflexion 21p · 04 Eigenständigkeitserklärung 2p) |
+| Repo safety-net bundle | SUBMISSION-bundle.pdf — 264 pages (NOT uploaded) |
+| Build status | `just package-submission` exit 0 · `just pdf-submission-bundle` exit 0 · layout-check passed for all 5 docs |
+
+> **Rubric note (June 2026):** the "framework concepts" programming item is now **framework-neutral** and **fully in scope for .NET** — it is no longer the old Quarkus/Jakarta-EE item and **no item is excluded**. Max achievable is **100 / 100**.
+
+---
+
+## 2. Overall result
+
+### FINAL score: **98 / 100**
+
+**Grade band: Excellent — top of the scale (≈ 6.0 / "sehr gut"); a submission-ready, defensible Projektarbeit.**
+
+FlowHub is an exemplary submission across every bucket: a closed 18-use-case + 50-AC specification, a complete Arc42 "as built" architecture (context/building-block/runtime/interface views, 7-entity ER with pgvector, 9 Accepted ADRs), an idiomatic hexagonal .NET 10 modular monolith with 540 green CI tests at 100 % line coverage, and a genuinely strong AI-and-architecture story that I confirmed first-hand on the live demo (real MEAI/OpenRouter classification routing two distinct inputs to Wallabag vs Vikunja with real downstream writes, graceful 503 embeddings fallback, active rate limiting, 15-min self-reset). The build produced all five upload PDFs cleanly with no clipping. The **only** points withheld are 2 in Spezifikation, because the full five-dimension SMART decomposition of the NfA is reachable only via a repo link (the rendered Arc42 Table 6 collapses to Ziel/Messung) and two privacy/AI-Act NfA carry deliberately open time-bounds. No skeptic dispute changed any first-pass score.
+
+---
+
+## 3. Per-bucket result
+
+| Bucket | First-pass | Final | Max |
+|---|---:|---:|---:|
+| Spezifikation | 13 | 13 | 15 |
+| Entwurf | 17 | 17 | 17 |
+| Programmierung | 22 | 22 | 22 |
+| Validierung | 16 | 16 | 16 |
+| KI und Architektur | 30 | 30 | 30 |
+| **Total** | **98** | **98** | **100** |
+
+---
+
+## 4. Per-item detail
+
+| Item | Scale | First-pass | Final | Justification (short) | Key evidence | Gap to next level |
+|---|---|---:|---:|---|---|---|
+| **Spezifikation** | | | | | | |
+| Wichtigste Use-Cases & fachl. Anforderungen benannt | 0/1/3/5 | 5 | 5 | Closed catalogue UC-01…UC-18, each Actor/Trigger/Pre/Flow/Post/Error + per-UC AC; 5 load-bearing flows fully rendered in PDF, rest in repo | upload.txt L542, L635-800; docs/spec/use-cases.md L13-346 | — (at top) |
+| Qualitätsanforderungen (NfA) nach SMART | 0/1/3/5 | 3 | 3 | Clears "mehrheitlich SMART" decisively; full 5-dimension decomposition is **repo-only** (Arc42 Table 6 shows only Ziel/Messung), and P1/P2 have open time-bounds | docs/spec/nfa.md L1-148; upload.txt L2243-2360, L471 | Render all 5 SMART dimensions in the PDF; give P1/P2 concrete time-bounds |
+| Vision der Lösung beschrieben | 0/1/3/5 | 5 | 5 | Dedicated Vision chapter + problem framing + 3 personas + before/after value in the **primary** Projektbeschreibung | upload.txt L2832-2900; docs/spec/use-cases.md L3-7 | — (at top) |
+| **Entwurf** | | | | | | |
+| Lösungsansatz & Architektur (bildlich + textuell) | 0/1/4/7 | 7 | 7 | Context (Abb.1) + Bausteinsicht (Abb.2) with consistent prose; style named (Modular Monolith + hexagonal) and justified by 9 Accepted ADRs; red thread end-to-end | upload.txt Arc42 Abb.1/Abb.2, Kap.4, Kap.9 Tab.5 | — (at top) |
+| Entwurf aus Struktur/Verhalten/Interaktion | 0/1/4/7 | 7 | 7 | All three perspectives with diagram+text: Bausteinsicht; state machine + 5 sequence diagrams; Schnittstellensicht Abb.4 + C1–C17 + OpenAPI/Scalar | upload.txt Arc42 Kap.5, Kap.6 (Abb.5-10), Kap.5.7 | — (at top) |
+| DB-Modell spezifiziert | 0/1/2/3 | 3 | 3 | Complete ER (Abb.3, 7 entities, PK/FK, pgvector Embedding) + 14 EF Core migrations + ADR 0006 | upload.txt Arc42 Abb.3; source/FlowHub.Persistence/Migrations (14); docs/design/db | — (at top) |
+| **Programmierung** | | | | | | |
+| Code lesbar/dokumentiert/nach Schichten & Modulen | 0/1/4/7 | 7 | 7 | Consistent 6-project hexagonal layout, thin endpoints delegating to services, guard clauses, per-module READMEs, Nullable+TreatWarningsAsErrors, boundaries match Bausteinsicht | source/ tree; CaptureWriteEndpoints.cs; Directory.Build.props | — (at top) |
+| Framework- & moderne App-Konzepte (DI/REST/Config/Fehler) | 0/3/7/10 | 10 | 10 | All four named concepts durchgehend idiomatic: per-module DI extensions, Minimal-API TypedResults, Options/IConfiguration, RFC 9457 ProblemDetails + FluentValidation; framework choice justified (ADR 0001/PE-1). Auth dev-stub is scoped roadmap, not a scored concept | docs/spec/modern-app-concepts.md; ProblemTypes.cs; *ServiceCollectionExtensions.cs; CreateCaptureRequestValidator.cs | — (at top) |
+| Erkenntnisse aus der Programmierung dokumentiert | 0/1/2/3 | 3 | 3 | Projektbeschreibung Kap.9 lists 5 concrete corrected/rejected-AI cases (embedding/NfA-09 p95, pgvector+MassTransit training-lag, compose interpolation/casing) — primary evidence | upload.txt L3936-3993; docs/ai-usage.md | — (at top) |
+| Source-Code im Git-Repository verfügbar | 0/2 | 2 | 2 | Repo URL in report; HTTP 200; complete source; 722 commits, no single-big-commit anomaly | upload.txt L5/L165; curl 200; git 722 commits | — (at top) |
+| **Validierung** | | | | | | |
+| Abnahmekriterien definiert | 0/1/3/5 | 5 | 5 | 50 traceable ACs, per-UC AC blocks in PDF with named verifying tests; full catalogue in repo (46 verified / 4 deferred) | upload.txt §8.9, L662-704; docs/spec/acceptance-criteria.md | — (at top) |
+| Test-Vorgehen & Technologien spezifiziert | 0/1/3/5 | 5 | 5 | Arc42 §8.8 names layered approach + stack (xUnit, bUnit, NSubstitute, FluentAssertions, Testcontainers, Playwright, trait-gated live-AI) | upload.txt §8.8, L364-365; docs/spec/testing-strategy.md | — (at top) |
+| Unit-Tests programmiert | 0/1/3 | 3 | 3 | Real, large suite: 93 *Tests.cs, 516 test attributes, 540 green CI tests across 6 projects (Testcontainers/bUnit/harness, not stubs) | filesystem counts; upload.txt L362-363 | — (at top) |
+| Test-Ergebnisse dokumentiert | 0/1/3 | 3 | 3 | Dated CI run #28324532702 (green 540/0), 100 % line / 94.6 % branch, committed HTML report + repro cmd. 294-vs-540 PDF wording is sub-threshold | upload.txt L362-379, §8.8; docs/coverage/*.html | — (at top) |
+| **KI und Architektur** | | | | | | |
+| KI-Werkzeuge verwendet & Nutzung beschrieben | 0/1/7/12 | 12 | 12 | Reflexion §1/§2 + deck slides 12-22 + Hilfsmittelverzeichnis/Selbständigkeitserklärung in upload: named tools, Block 1→5 evolution, generated-vs-handwritten shares, commit-linked corrections | upload.txt L4450-4540, L4181-4399, L4844-4958; docs/ai-usage.md | — (at top) |
+| Intelligente & flexible Services gebaut | 0/2/6 | 6 | 6 | **Live-demo confirmed:** AiClassifier (MEAI/OpenRouter) routed arXiv URL→Wallabag and task→Vikunja, enriched titles, full classifier trace; AiEmbeddingService over pgvector; KeywordClassifier graceful fallback (EventId 3010) | live round-trip (capture f8bde2e3 + 5ae0c17a); source/FlowHub.AI; upload.txt L1155,L1174,L1994 | — (at top) |
+| Klar abgegrenzte Module/Sub-Systeme + als Container betrieben | 0/1/3/5 | 5 | 5 | Modular monolith (ADR 0002) runs as container stack (Compose, 2 first-party images + backing services, live demo). **Live-demo:** 3 sandboxed sub-systems (Vikunja/Wallabag/paperless) reachable, healthy, each received a real write. June-2026 rubric accepts modular monolith for full marks | upload.txt §3.6, Arc42 §7.1; live Integration-health panel; Bewertungskriterien.md L124-129 | — (at top) |
+| Erfahrungen mit KI als Fazit reflektiert | 0/1/4/7 | 7 | 7 | Reflexion §7 revisits Block-1 hypothesis, §8 Fazit + three evidenced Veto-Entscheidungen, §6 "was anders" — self-critical, complete | upload.txt L4674-4755, L4650-4669, L4615-4644 | — (at top) |
+
+---
+
+## 5. Live demo walkthrough
+
+**Reachability.** `GET /` = 200, `GET /health/live` = 200 ("Healthy"). Demo fully live.
+
+**What was submitted & how it classified (first-hand evidence).**
+- Capture 1 — a bare arXiv read-later URL. POST `/api/v1/captures` → 201 (stage `Raw`); within ~2 s advanced to **Completed**. `matchedSkill=Wallabag` (correct), AI-enriched title `"Attention Is All You Need Paper"` (resolved the bare id to the real paper), real `externalRef=26` (an actual Wallabag write), `classifierTrace.kind=Ai` via OpenRouter `google/gemma-4-31b-it:free`, latency 5114 ms, 319/68 tokens. `captureId=f8bde2e3-329b-462b-87a3-b987abc4857c`.
+- Capture 2 — `"todo: buy milk and call the dentist tomorrow"` → **Vikunja**, title `"Buy milk and call dentist"`, `vikunjaProject=Inbox`, `externalRef=72`, Completed. Demonstrates classification variety (URL→Wallabag vs task→Vikunja) and a second live downstream write.
+
+This is **not** a stub or keyword fallback — it directly substantiates both the "intelligent und flexibel" and the "Sub-Systeme als Container betrieben" rubric items.
+
+**Embeddings posture.** `/api/v1/captures/search?q=paper` → **503** with a clean RFC 9457 ProblemDetails body (type → docs/problems/validation.md, title "Semantic search not available.", names missing `Embeddings__ApiKey`, instance + traceId). Transparent, deliberate disablement — surfaced to the user in the banner.
+
+**Rate limiting.** 25 rapid GETs: reqs 1-19 → 200, 20-21 → 429, 22-25 recovered to 200. A sliding/token-bucket limiter is active but lenient and refills within the burst; no `RateLimit-*`/`Retry-After` headers (only `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `X-XSS-Protection`).
+
+**Reset / honesty.** Home HTML carries an explicit demo banner: routes a todo→Vikunja, URL→Wallabag, PDF/image→paperless-ngx; "Data resets every 15 min; semantic search is off." Links to three sandboxed instances with shared demo creds and an external uptime-kuma status page. The 15-min self-reset and embeddings-off posture are disclosed, not hidden.
+
+**Screenshots.**
+- `./nachbereitung/examiner-sim/screenshots/home-2026-06-28T1909.png`
+- `./nachbereitung/examiner-sim/screenshots/captures-list-2026-06-28T1909.png`
+
+**Demo issues to be aware of (none affect score):**
+1. Trace model id `google/gemma-4-31b-it:free` — no public Gemma 4 / Gemma-4-31B exists (latest public is Gemma 3); likely an OpenRouter free-tier alias or typo. An examiner may ask whether the trace faithfully reports the served model — worth verifying/annotating.
+2. Rate limiter is lenient and self-recovering (2/25 rejected, no rate-limit headers) — more cosmetic than protective; lacks header hygiene.
+3. `enrichmentDescription` was null for both captures; banner advertises a cost figure the API surface does not return (only token counts).
+4. Dashboard shows pre-seeded Unhandled/Orphan captures (e.g. "Receipt — Migros") — expected demo fixtures, but confirm they are intentional, not silent classification failures.
+5. No distinct `/captures` route observed — the "captures-list" screenshot resolves to the dashboard recent-captures view.
+
+---
+
+## 6. Top gaps ranked by point-leverage
+
+The submission is at 98/100, so leverage is concentrated in **one** bucket.
+
+1. **NfA SMART rendering — up to +2 pts (Spezifikation, 3→5).** The single highest-leverage fix. Render the full five-dimension SMART decomposition (Achievable / Relevant / Time-bound per NfA) **directly in the Arc42 PDF** instead of collapsing Table 6 to Ziel/Messung with a repo pointer. This is the cheapest available point: the content already exists complete in `docs/spec/nfa.md` — it just isn't in the artifact Moodle receives.
+2. **Bound the two open NfA — part of the same +2.** Give NfA-P1 (Personendaten-Residenz) and NfA-P2 (KI-Transparenz) concrete time-bounds, or move them out of the core NfA set, instead of "Offen — nach der CAS-Abgabe."
+3. **Reconcile the 294-vs-540 test count in the PDFs — 0 pts but defensive.** Arc42 §8.8 (294 offline) and the Übersicht (540 full CI) disagree on the surface; the reconciliation lives only in repo-level testing-strategy.md. Sub-threshold today, but a strict examiner will flag it — fix the wording in both PDFs.
+4. **Surface repo-only evidence in the PDFs — 0 pts but defensive.** Per-block AI-usage percentages, the full 50-AC catalogue, and the complete UC catalogue are repo-only. Already top-scored, but a one-paragraph inline summary removes any "follow the repo link" dependency in the oral.
+
+---
+
+## 7. Defense questions (sharpest a real examiner would ask)
+
+**Spezifikation**
+1. Your Arc42 NfA table shows only Ziel/Messung — walk me through the Achievable, Relevant and Time-bound dimensions for NfA-09 (p95 < 200 ms) without opening the repo.
+2. NfA-P1 and NfA-P2 are time-bounded "after the CAS submission." Why are privacy-residency and AI-transparency open-ended, and how is that compatible with calling them SMART?
+
+**Entwurf**
+3. You name nine ADRs, all Accepted. Was any decision genuinely contested — show me an ADR where you rejected the alternative you initially preferred, and why.
+4. The ER diagram puts a pgvector Embedding column on Captures. Why store embeddings inline rather than in a separate vector table, and what does that cost you on write throughput?
+
+**Programmierung**
+5. The framework-concepts item is now in scope for .NET. Defend "durchgehend idiomatic" given the `DemoAuthHandler` dev-auth bypass — where is the real OIDC boundary and why is the stub acceptable for submission?
+6. Show me one AI-generated suggestion you rejected, the invariant it violated, and the commit that corrected it. (Expected: Embedding-on-Submit → CaptureEmbeddingConsumer, NfA-09 p95 budget.)
+
+**Validierung**
+7. Arc42 says 294 offline tests, the Übersicht says 540. Which is true, and why do two uploaded documents disagree?
+8. 100 % line coverage but 94.6 % branch — which branches are uncovered, and is 100 % line coverage a meaningful quality signal or a vanity metric here?
+
+**KI und Architektur (live demo)**
+9. Your classifier trace reports `google/gemma-4-31b-it:free` — there is no public Gemma 4. Does the trace faithfully report the served model, or is this an alias/typo?
+10. You call this "Sub-Systeme als Container betrieben," but FlowHub.Api is folded in-process and only web+migrations are first-party images. Justify the modular-monolith choice over independently deployable services.
+11. Semantic search is off in the demo (503). How do you evidence that the embedding pipeline actually works, and why disable it for the examiner?
+12. Your rate limiter rejected 2 of 25 requests with no Retry-After header. Is that protection or decoration — what's the actual policy and how would a well-behaved client discover it?
+
+---
+
+## 8. Skeptic disputes & resolution
+
+| Bucket | Item | Claimed | Skeptic recommended | Resolution |
+|---|---|---:|---:|---|
+| Spezifikation | NfA nach SMART | 3 | 3 | Fair — full 5-dimension SMART is repo-only (A/R/T absent from upload.txt); 3/5 upheld. |
+| Entwurf | (all three items) | 17 | 17 | Fair — every figure, the C1–C17 table, 9 ADRs, 7-entity ER, 14 migrations verified present; 17/17 stands. |
+| Programmierung | Framework-Konzepte (DI/REST/Config/Fehler) | 10 | 10 | Challenged hardest on the DemoAuthHandler dev-bypass; auth is not one of the 4 scored concepts and is scoped roadmap, all 4 verified idiomatic → 10 holds. |
+| Programmierung | Code-Struktur / Erkenntnisse / Git | 12 | 12 | Fair — corroborated in both PDF and live repo; minor nit (ai-usage.md 552 not 531 lines) is harmless. |
+| Validierung | Test-Ergebnisse dokumentiert | 3 | 3 | 294-vs-540 inconsistency is real but sub-threshold on a 0/1/3 scale; documented results (CI run, coverage, HTML) hold the top level. |
+| KI und Architektur | All four items (12/6/5/7) | 30 | 30 | Fair — every item verified in upload.txt at claimed strength and reinforced first-hand by the live demo; no over-award. |
+
+**Net effect of skepticism on the final score: 0 points.** Every first-pass value survived adversarial review and equals the final value.


### PR DESCRIPTION
## Summary
Adds the 2026-06-28 balanced examiner-sim grade sheet (98/100) under `nachbereitung/examiner-sim/`.

## Notes
Single docs commit (`aec3e30`), no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)