### PR TITLE
fix(deps): pin patched transitive Microsoft.OpenApi + Scriban.Signed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -102,4 +102,13 @@
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
 
+  <ItemGroup Label="Security transitive pins">
+    <!-- Force patched transitive versions to clear NuGetAudit (NU1903) high-severity
+         advisories. Transitive pinning is enabled above (CentralPackageTransitivePinningEnabled). -->
+    <!-- Microsoft.OpenApi 2.0.0 (via Microsoft.AspNetCore.OpenApi) → GHSA-v5pm-xwqc-g5wc -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
+    <!-- Scriban.Signed 5.5.0 (via WireMock.Net, test-only) → GHSA-24c8-4792-22hx -->
+    <PackageVersion Include="Scriban.Signed" Version="7.2.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Problem
Two newly-published **high-severity** advisories started failing `dotnet restore` (NuGetAudit `NU1903`, warnings-as-errors) on **every** build — including `main` and every open PR:

| Package | Via | Was | Advisory |
|---|---|---|---|
| `Microsoft.OpenApi` | `Microsoft.AspNetCore.OpenApi` | 2.0.0 | [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) |
| `Scriban.Signed` | `WireMock.Net` (test-only) | 5.5.0 | [GHSA-24c8-4792-22hx](https://github.com/advisories/GHSA-24c8-4792-22hx) |

## Fix
Transitive-pin both to their first patched versions via CPM (`CentralPackageTransitivePinningEnabled` is already on): `Microsoft.OpenApi 2.7.5`, `Scriban.Signed 7.2.0`.

## Verification (local)
- `dotnet restore` clean; `dotnet list package --vulnerable --include-transitive` → **empty across all 15 projects**
- `dotnet build` → 0 warnings / 0 errors (warnings-as-errors would catch any API breakage from the Scriban 5.x→7.x jump)
- Full offline suite green — incl. `FlowHub.Skills.ContractTests` 17/17 which exercise the WireMock/Scriban templating path

🤖 Generated with [Claude Code](https://claude.com/claude-code)