### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-03
+
+### Fixed
+
+- **deps:** pin patched transitive Microsoft.OpenApi (2.7.5) + Scriban.Signed (7.2.0) to clear high-severity NuGetAudit advisories (GHSA-v5pm-xwqc-g5wc, GHSA-24c8-4792-22hx) (#172)
+
+### Documentation
+
+- **roadmap:** add tracked security & AI-risk hardening section (G1–G4 + #167) (#173)
+- **examiner-sim:** add 2026-06-28 balanced grade sheet (98/100) (#171)
+- **tests:** align offline test count 294 -> 540 (current verified suite) (#170)
+- **agent-dev:** swap=0 OOM guard + Claude grep->ugrep root cause (#169)
+- **skills:** enrich #167 — spec + plan for IsPublic simplification (#168)
+- **coverage:** point coverage links to canonical https Pages URL (#166)
+
 ## [0.3.0] - 2026-06-28
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <WarningsNotAsErrors></WarningsNotAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <DebugType>embedded</DebugType>
     <Deterministic>true</Deterministic>
 


### PR DESCRIPTION
## Release v0.3.1 (PATCH)

Bumps `Directory.Build.props` 0.3.0 → 0.3.1 and adds the CHANGELOG section for the 7 commits since v0.3.0.

**Why PATCH:** the only non-doc change is `fix(deps)` (#172, the transitive security pins) — no `feat` commits, so per Conventional Commits this is a patch.

### Included since v0.3.0
- **fix(deps)** #172 — patched transitive Microsoft.OpenApi 2.7.5 + Scriban.Signed 7.2.0 (clears two high-severity advisories)
- **docs** #166, #168, #169, #170, #171, #173

### On merge
Pushing the `v0.3.1` tag triggers `release.yml` → builds/pushes GHCR images + creates the GitHub Release (notes via git-cliff-action). Tag applied post-merge to the squashed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)