### PR TITLE
chore(security): allowlist two reviewed gitleaks false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,17 @@
+# gitleaks allowlist — reviewed false positives.
+#
+# Each entry is a gitleaks finding fingerprint (commit:path:rule:line) that was
+# manually reviewed and confirmed NOT to be a real credential. Reviewed 2026-07-03.
+# Format: one fingerprint per line; see https://github.com/gitleaks/gitleaks#gitleaksignore
+
+# Makefile (no longer in the tree — history only). gitleaks' curl-auth-user rule
+# flagged a RabbitMQ health-ping `curl -u "$USER:$PASS"` whose password DEFAULTS to
+# the local-dev value `dev-secret` for a localhost broker. Not a credential to any
+# real system — a dev fallback overridden by env in every real deployment.
+e03d0cebe05bda8775479d1d0329733301481b28:Makefile:curl-auth-user:180
+
+# tools/wallabag-token.sh — OAUTH_CLIENT_RESOURCE is a Passbolt *resource UUID*
+# (an identifier that points to a secret stored in Passbolt), NOT the secret itself.
+# Retrieving the actual value still requires authenticated Passbolt access; the UUID
+# alone is inert. See docs/runbooks/test-services.md § Secrets.
+5eafafb427a6ebc61cf12fb191bf43f58a4d0c98:tools/wallabag-token.sh:generic-api-key:25


### PR DESCRIPTION
## Summary
Adds `.gitleaksignore` so a full-history `gitleaks detect` returns **clean (0 findings)** and documents that the two hits were reviewed.

Both are confirmed **false positives** (reviewed 2026-07-03):

| Fingerprint | Why it's safe |
|---|---|
| `Makefile:180` (history-only, file removed) | RabbitMQ health-ping `curl -u` using the local-dev default `dev-secret` for a **localhost** broker — not a real credential |
| `tools/wallabag-token.sh:25` | `OAUTH_CLIENT_RESOURCE` is a **Passbolt resource UUID** (pointer to a vaulted secret), not the secret; retrieval needs Passbolt auth |

Context: GitHub secret-scanning already reports **no alerts**; this makes the local/CI full-history audit green and records the rationale inline.

## Scope
Single new file (`.gitleaksignore`), comment-documented. No code/secret changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)