### PR TITLE
fix(deps): bump Scriban.Signed 7.2.0 → 7.2.5 (NU1902)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -107,8 +107,9 @@
          advisories. Transitive pinning is enabled above (CentralPackageTransitivePinningEnabled). -->
     <!-- Microsoft.OpenApi 2.0.0 (via Microsoft.AspNetCore.OpenApi) → GHSA-v5pm-xwqc-g5wc -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
-    <!-- Scriban.Signed 5.5.0 (via WireMock.Net, test-only) → GHSA-24c8-4792-22hx -->
-    <PackageVersion Include="Scriban.Signed" Version="7.2.0" />
+    <!-- Scriban.Signed (via WireMock.Net, test-only) → GHSA-24c8-4792-22hx,
+         GHSA-6q7j-xr26-3h2c, GHSA-q6rr-fm2g-g5x8 (patched in 7.2.1) -->
+    <PackageVersion Include="Scriban.Signed" Version="7.2.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What

Bumps `Scriban.Signed` `7.2.0` → `7.2.5` in `Directory.Packages.props`.

## Why

Two moderate-severity advisories were just published for Scriban.Signed ≤ 7.2.0 (both patched in 7.2.1):

- [GHSA-6q7j-xr26-3h2c](https://github.com/advisories/GHSA-6q7j-xr26-3h2c)
- [GHSA-q6rr-fm2g-g5x8](https://github.com/advisories/GHSA-q6rr-fm2g-g5x8)

Under this repo's warnings-as-errors + NuGetAudit policy, `NU1902` fails `dotnet restore`, turning **all** of `main`'s `build-and-test` and `quality` jobs red. This is unrelated to any feature work — the advisory simply dropped for a package already in the tree.

`Scriban.Signed` is a **test-only** transitive dependency (via WireMock.Net).

## Verification

```
dotnet list FlowHub.slnx package --vulnerable --include-transitive
→ no vulnerable packages across all 15 projects
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5qd2xewbfmZW4YW29WzSe