### PR TITLE
feat(demo): harden demo monitoring — basic-auth Kuma admin + homelab outside-watcher

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -21,6 +21,13 @@ Ai__OpenRouter__ApiKey=sk-or-v1-...
 # to it. Defaults to `traefik_public`.
 # TRAEFIK_NETWORK=traefik_public
 
+# Basic-auth for the Uptime Kuma ADMIN UI (status.demo.flowhub…/dashboard). The
+# public status page (/status/<slug>) stays open; everything else is gated at the
+# Traefik edge. Generate with: htpasswd -nbB admin '<strong-password>'
+# Paste the full `user:$2y$...` line as-is (no $ escaping needed via this var).
+# If unset, the admin fails closed (401) while the status page remains public.
+# KUMA_BASICAUTH_USERS=admin:$2y$05$exampleexampleexampleexampleexampleexampleexam
+
 # Postgres + RabbitMQ creds are demo-local — randomise per deployment.
 POSTGRES_PASSWORD=demo-secret-rotate-me
 RABBITMQ_USER=flowhub

--- a/demo/docker-compose.vps.yml
+++ b/demo/docker-compose.vps.yml
@@ -77,14 +77,28 @@ services:
       - "traefik.http.middlewares.flowhub-paperless-ratelimit.ratelimit.period=1m"
       - "traefik.docker.network=web"
 
+  # Split access at the edge: /status/* stays public, everything else (admin) is
+  # basic-auth gated. See the base demo/docker-compose.yml uptime-kuma comment.
+  # Set KUMA_BASICAUTH_USERS in .env (htpasswd -nbB output); unset ⇒ admin 401s.
   uptime-kuma:
     labels: !override
       - "traefik.enable=true"
+      # Public status page — read-only paths Kuma needs to render /status/<slug>.
+      - "traefik.http.routers.flowhub-status-public.rule=Host(`status.demo.flowhub.freaxnx01.ch`) && (PathPrefix(`/status`) || PathPrefix(`/assets`) || PathPrefix(`/api/status-page`) || PathPrefix(`/api/badge`) || PathPrefix(`/upload`) || Path(`/favicon.ico`) || Path(`/icon.svg`) || Path(`/manifest.json`) || Path(`/apple-touch-icon.png`))"
+      - "traefik.http.routers.flowhub-status-public.priority=100"
+      - "traefik.http.routers.flowhub-status-public.entrypoints=web-secure"
+      - "traefik.http.routers.flowhub-status-public.tls=true"
+      - "traefik.http.routers.flowhub-status-public.tls.certresolver=default"
+      - "traefik.http.routers.flowhub-status-public.middlewares=flowhub-status-ratelimit@docker"
+      - "traefik.http.routers.flowhub-status-public.service=flowhub-status"
+      # Catch-all — the admin UI, basic-auth gated on top of the rate limit.
       - "traefik.http.routers.flowhub-status.rule=Host(`status.demo.flowhub.freaxnx01.ch`)"
+      - "traefik.http.routers.flowhub-status.priority=1"
       - "traefik.http.routers.flowhub-status.entrypoints=web-secure"
       - "traefik.http.routers.flowhub-status.tls=true"
       - "traefik.http.routers.flowhub-status.tls.certresolver=default"
-      - "traefik.http.routers.flowhub-status.middlewares=flowhub-status-ratelimit@docker"
+      - "traefik.http.routers.flowhub-status.middlewares=flowhub-status-ratelimit@docker,flowhub-status-auth@docker"
+      - "traefik.http.middlewares.flowhub-status-auth.basicauth.users=${KUMA_BASICAUTH_USERS:-}"
       - "traefik.http.services.flowhub-status.loadbalancer.server.port=3001"
       - "traefik.http.middlewares.flowhub-status-ratelimit.ratelimit.average=100"
       - "traefik.http.middlewares.flowhub-status-ratelimit.ratelimit.burst=200"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -473,6 +473,15 @@ services:
   # public status page that probes the demo's health endpoints, the skill-target
   # services, and the LLM provider. Monitors are configured on first boot —
   # see docs/runbooks/public-demo.md § Uptime monitoring.
+  #
+  # Kuma serves BOTH the public status page and the admin UI from the same host/port,
+  # so access is split at the Traefik edge by path (see also demo/docker-compose.vps.yml,
+  # which !override-s these labels for the live VPS-DE Traefik):
+  #   * flowhub-status-public (priority 100) — the status-page read paths, no auth.
+  #   * flowhub-status        (catch-all)     — everything else (admin, /dashboard,
+  #     socket.io, setup) behind HTTP basic-auth. Set KUMA_BASICAUTH_USERS in .env to
+  #     an `htpasswd -nbB <user> <pass>` line; if unset the admin fails closed (401)
+  #     while the status page stays public.
   uptime-kuma:
     image: louislam/uptime-kuma:1
     volumes:
@@ -480,11 +489,22 @@ services:
     labels:
       # Generic labels (overridden for VPS-DE in demo/docker-compose.vps.yml).
       - "traefik.enable=true"
+      # Public status page — read-only paths Kuma needs to render /status/<slug>.
+      - "traefik.http.routers.flowhub-status-public.rule=Host(`status.demo.flowhub.freaxnx01.ch`) && (PathPrefix(`/status`) || PathPrefix(`/assets`) || PathPrefix(`/api/status-page`) || PathPrefix(`/api/badge`) || PathPrefix(`/upload`) || Path(`/favicon.ico`) || Path(`/icon.svg`) || Path(`/manifest.json`) || Path(`/apple-touch-icon.png`))"
+      - "traefik.http.routers.flowhub-status-public.priority=100"
+      - "traefik.http.routers.flowhub-status-public.entrypoints=websecure"
+      - "traefik.http.routers.flowhub-status-public.tls=true"
+      - "traefik.http.routers.flowhub-status-public.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.flowhub-status-public.middlewares=flowhub-status-ratelimit@docker"
+      - "traefik.http.routers.flowhub-status-public.service=flowhub-status"
+      # Catch-all — the admin UI. Basic-auth gated on top of the rate limit.
       - "traefik.http.routers.flowhub-status.rule=Host(`status.demo.flowhub.freaxnx01.ch`)"
+      - "traefik.http.routers.flowhub-status.priority=1"
       - "traefik.http.routers.flowhub-status.entrypoints=websecure"
       - "traefik.http.routers.flowhub-status.tls=true"
       - "traefik.http.routers.flowhub-status.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.flowhub-status.middlewares=flowhub-status-ratelimit@docker"
+      - "traefik.http.routers.flowhub-status.middlewares=flowhub-status-ratelimit@docker,flowhub-status-auth@docker"
+      - "traefik.http.middlewares.flowhub-status-auth.basicauth.users=${KUMA_BASICAUTH_USERS:-}"
       - "traefik.http.middlewares.flowhub-status-ratelimit.ratelimit.average=100"
       - "traefik.http.middlewares.flowhub-status-ratelimit.ratelimit.burst=200"
       - "traefik.http.middlewares.flowhub-status-ratelimit.ratelimit.period=1m"

--- a/demo/homelab-watcher/README.md
+++ b/demo/homelab-watcher/README.md
@@ -1,0 +1,105 @@
+# Homelab "outside watcher" — Uptime Kuma
+
+A second Uptime Kuma that runs in the **homelab** and monitors the **VPS-DE public
+demo from the outside**, pushing alerts to the homelab **ntfy**.
+
+## Why
+
+The VPS-DE Kuma (`status.demo.flowhub.freaxnx01.ch`) watches each demo service, but
+it runs *on the VPS* — so it cannot alert when the VPS host or its network dies.
+That is exactly the failure you must not miss right before an examiner connects.
+
+This watcher closes that gap: it lives off-VPS, so a total VPS/network outage still
+reaches your phone. Two layers, each covering the other's blind spot:
+
+| Layer | Runs on | Catches | Alerts via |
+|-------|---------|---------|------------|
+| VPS Kuma | VPS-DE | per-service failures (app, DB, skill targets, LLM) | ntfy |
+| **This watcher** | **homelab** | **whole-VPS / network death** | **homelab ntfy** |
+
+> Scope: this watcher assumes the homelab is the more stable side (you'd notice if
+> your own homelab were down). If you ever want alerting that survives the homelab
+> being down too, add a free external check (healthchecks.io / UptimeRobot) as a
+> third layer.
+
+## Deployed instance (2026-07-05)
+
+Provisioned in the homelab as a dedicated LXC (kept separate from the existing
+`uptimekuma1` at `.156`, which watches homelab services):
+
+| | |
+|---|---|
+| Proxmox node | `odroid-plus-pve` |
+| LXC | `140` (`flowhub-watcher`), unprivileged, `nesting=1,keyctl=1`, `onboot=1` |
+| IP | `192.168.1.148/24` |
+| UI (LAN) | `https://status.home.freaxnx01.ch` (Local-only) or `http://192.168.1.148:3011` |
+| Compose | `/opt/flowhub-watcher/docker-compose.yml` inside the LXC |
+| Routing | dispatcher `dynamic.yml` HTTP route → `http://192.168.1.148:3011`; PiHole `status.home → 192.168.1.162`; no Cloudflare record |
+
+**Still operator-facing:** create the Kuma admin account, add the monitors, and
+wire ntfy (below) — Kuma stores these in its SQLite volume, not declaratively.
+
+## Deploy
+
+1. Copy this `docker-compose.yml` into the target LXC's docker stack (e.g. merge
+   the `flowhub-watcher` service into `~/mydocker/docker-compose.yml`, or run it
+   standalone from this folder).
+2. Confirm `COMPOSE_PROJECT_NAME=mydocker` is set in that LXC's `.env`
+   (homelab-service-routing skill, Critical Rule 2 — prevents orphaned volumes).
+3. `docker compose up -d`
+4. Reach the UI at `http://<lxc-ip>:3011` (fallback port) and create the admin
+   account. Optionally expose it at `status.home.freaxnx01.ch` — see **Routing**.
+
+## Monitors (configured 2026-07-05)
+
+Six HTTP(s) monitors, all probing the **public** VPS endpoints from outside
+(interval 60 s, 3 retries, ntfy attached). Set up via `uptime-kuma-api`:
+
+| Monitor | URL | Accepted |
+|---------|-----|----------|
+| FlowHub demo — liveness | `https://demo.flowhub.freaxnx01.ch/health/live` | 200–299 |
+| FlowHub demo — web app (root) | `https://demo.flowhub.freaxnx01.ch/` | 200–299 |
+| FlowHub demo — status page | `https://status.demo.flowhub.freaxnx01.ch/status/flowhub-demo` | 200–299 |
+| Vikunja (demo skill target) | `https://vikunja.demo.flowhub.freaxnx01.ch` | 200–399 |
+| Wallabag (demo skill target) | `https://wallabag.demo.flowhub.freaxnx01.ch` | 200–399 |
+| Paperless (demo skill target) | `https://paperless.demo.flowhub.freaxnx01.ch` | 200–399 |
+
+> **Note:** `/health/ready` is **404 at the public edge** (readiness is internal-only),
+> so the second monitor checks the app **root** (`/`) instead — that's what the
+> examiner actually loads. Admin creds for the Kuma UI are in **Passbolt**
+> ("FlowHub demo watcher — Uptime Kuma (homelab .148)").
+
+## ntfy notifications (configured)
+
+Kuma pushes to homelab ntfy, **urgent priority** (breaks through DND):
+
+- **Server URL:** `https://ntfy.home.freaxnx01.ch`
+- **Topic:** `flowhub-demo-status` — granted **anonymous write-only** on the ntfy
+  server (mirrors the app's existing `flowhub-demo-captures` topic), so Kuma needs
+  no token. **Subscribe as the `freax` ntfy user to read it** (server is `deny-all`).
+- Verified end-to-end 2026-07-05: a forced DOWN monitor delivered a priority-5
+  `Down [Uptime-Kuma]` push to the topic.
+
+To reproduce/repair the monitors + notification, the `uptime-kuma-api` scripts used
+here are ephemeral; re-run against `http://192.168.1.148:3011` with the Passbolt
+admin creds, or add them via the UI (Settings → Notifications → type `ntfy`).
+
+## Routing (optional — expose the watcher UI at status.home.freaxnx01.ch)
+
+The watcher works without this (it only needs outbound). To view its UI on a clean
+hostname, use the **homelab-service-routing** skill, **Local-only** access mode
+(no Cloudflare record — you don't need this reachable from the internet):
+
+1. **Dispatcher** (`~/projects/mydocker-compose/services/traefik/traefik/dynamic.yml`):
+   add a TCP-passthrough route `status.home.freaxnx01.ch` → `<lxc-ip>:443`
+   (requires the local-Traefik labels in `docker-compose.yml` uncommented), commit,
+   push, pull on dispatcher LXC 110.
+2. **PiHole**: add `192.168.1.162 status.home.freaxnx01.ch` to the shared
+   `common/pihole/custom.list`; restart both PiHole containers.
+3. **Cloudflare**: none (Local-only).
+
+## Pre-exam check
+
+~30 min before an exam window: open this watcher, confirm all monitors green, and
+confirm the ntfy test alert reached your phone. This watcher is what tells you if
+the VPS is unreachable *before* the examiner discovers it.

--- a/demo/homelab-watcher/docker-compose.yml
+++ b/demo/homelab-watcher/docker-compose.yml
@@ -1,0 +1,44 @@
+# FlowHub demo — homelab "outside watcher" (Uptime Kuma)
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS
+# The Uptime Kuma on the VPS-DE (status.demo.flowhub.freaxnx01.ch) monitors each
+# demo service, but it CANNOT alert when the VPS itself dies — the monitor dies
+# with the host. This second Kuma runs in the HOMELAB and probes the VPS demo
+# from the outside, pushing to the homelab ntfy. It is the layer that catches a
+# total VPS / network outage right before an exam.
+#
+# Its job (probe VPS + push ntfy) is entirely OUTBOUND, so it needs no inbound
+# route to function. The optional Traefik labels / host port below only expose
+# its own admin UI at status.home.freaxnx01.ch for convenience.
+#
+# DEPLOY: drop this into the target LXC's docker stack (e.g. ~/mydocker) and
+# `docker compose up -d`. Ensure COMPOSE_PROJECT_NAME=mydocker is set in that
+# LXC's .env (see homelab-service-routing skill, Critical Rule 2 — avoids
+# orphaned volumes on down/up). Then configure monitors + ntfy per README.md.
+services:
+  flowhub-watcher:
+    image: louislam/uptime-kuma:1
+    container_name: flowhub-watcher
+    restart: unless-stopped
+    volumes:
+      - flowhub-watcher-data:/app/data
+    # Fallback access with zero routing: reach the UI at http://<lxc-ip>:3011.
+    # Kuma listens on 3001 inside the container; mapped to 3011 on the host to
+    # avoid clashing with any local service already on 3001.
+    ports:
+      - "3011:3001"
+    # OPTIONAL — expose the admin UI at status.home.freaxnx01.ch via the LXC's
+    # LOCAL Traefik (HTTP mode; local Traefik terminates TLS via dnschallenge,
+    # the dispatcher TCP-passthrough-routes the hostname to this LXC:443).
+    # Uncomment and adapt the network/entrypoint names to the host LXC's Traefik.
+    # labels:
+    #   - "traefik.enable=true"
+    #   - "traefik.http.routers.flowhub-watcher.rule=Host(`status.home.freaxnx01.ch`)"
+    #   - "traefik.http.routers.flowhub-watcher.entrypoints=web-secure"
+    #   - "traefik.http.routers.flowhub-watcher.tls=true"
+    #   - "traefik.http.routers.flowhub-watcher.tls.certresolver=dnschallenge"
+    #   - "traefik.http.services.flowhub-watcher.loadbalancer.server.port=3001"
+
+volumes:
+  # Kuma config + monitor history (SQLite). Persists monitors + notifications.
+  flowhub-watcher-data:


### PR DESCRIPTION
## Summary

Two related changes hardening the public demo's monitoring ahead of exam windows.

### 1. Basic-auth gate the VPS Uptime Kuma admin at the Traefik edge
On `status.demo.flowhub.freaxnx01.ch`, access is now split by path:
- **`flowhub-status-public`** (priority 100) — the read-only paths Kuma needs to render `/status/<slug>` stay open (`/status`, `/assets`, `/api/status-page`, `/api/badge`, icons, manifest).
- **`flowhub-status`** (catch-all, priority 1) — the admin UI / `/dashboard` / socket.io / setup now sit behind HTTP basic-auth, on top of the existing rate limit.
- New `KUMA_BASICAUTH_USERS` var (an `htpasswd -nbB` line) documented in `.env.example`. **Fails closed (401)** if unset — the public status page stays up regardless.
- Mirrored in both the base `docker-compose.yml` (`websecure` / `letsencrypt`) and the `docker-compose.vps.yml` `!override` block (`web-secure` / `default`).

### 2. Homelab "outside-watcher" (second Uptime Kuma)
A second Kuma that runs in the **homelab** (LXC 140 / .148) and probes the VPS-DE public demo **from outside**, pushing to homelab ntfy. It catches a total VPS / network death that the on-VPS Kuma can't — that monitor dies with the host. Fully outbound; the optional Traefik labels only expose its own admin UI at `status.home.freaxnx01.ch`. Ships the compose file plus a README documenting the deployed instance, six monitors, and ntfy wiring (verified end-to-end 2026-07-05).

## Test plan
- [ ] Public status page (`/status/flowhub-demo`) loads without auth.
- [ ] Admin UI (`/dashboard`) prompts for basic-auth; 401 when `KUMA_BASICAUTH_USERS` unset.
- [ ] Homelab watcher green on all six monitors; forced-DOWN delivers a priority-5 ntfy push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)